### PR TITLE
Add manipulation insights analysis

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -4,6 +4,13 @@ import json
 from datetime import datetime
 from typing import Dict, Any, List
 
+from insight_helpers import (
+    compute_manipulation_ratio,
+    compute_manipulation_timeline,
+    compute_most_manipulative_message,
+    compute_dominance_metrics,
+)
+
 import dash
 from dash import dcc, html
 from dash.dependencies import Input, Output, State
@@ -74,7 +81,20 @@ def analyze_conversation(conv: Dict[str, Any]) -> Dict[str, Any]:
         'parasocial_pressure': sum(1 for f in features if f['flags'].get('flattery')),
         'reinforcement_loops': sum(1 for f in features if f['flags'].get('urgency') or f['flags'].get('fomo')),
     }
-    return {'features': features, 'risk': risk, 'summary': summary}
+    manipulation_ratio = compute_manipulation_ratio(features)
+    manipulation_timeline = compute_manipulation_timeline(features)
+    most_manipulative = compute_most_manipulative_message(features)
+    dominance_metrics = compute_dominance_metrics(features)
+
+    return {
+        'features': features,
+        'risk': risk,
+        'summary': summary,
+        'manipulation_ratio': manipulation_ratio,
+        'manipulation_timeline': manipulation_timeline,
+        'most_manipulative': most_manipulative,
+        'dominance_metrics': dominance_metrics,
+    }
 
 
 external_stylesheets = [dbc.themes.DARKLY]

--- a/insight_helpers.py
+++ b/insight_helpers.py
@@ -1,0 +1,73 @@
+from typing import List, Dict, Any
+
+def compute_manipulation_ratio(features: List[Dict[str, Any]]) -> float:
+    total = len(features)
+    if total == 0:
+        return 0.0
+    manipulative = 0
+    for f in features:
+        flags = f.get('flags', {})
+        if any(flags.get(k) for k in ['urgency', 'guilt', 'flattery', 'fomo', 'dark_ui']) or flags.get('emotion_count', 0) > 0:
+            manipulative += 1
+    return manipulative / total
+
+
+def compute_manipulation_timeline(features: List[Dict[str, Any]]) -> List[int]:
+    timeline = []
+    for f in features:
+        flags = f.get('flags', {})
+        count = int(flags.get('urgency', False)) + int(flags.get('guilt', False)) + int(flags.get('flattery', False)) + int(flags.get('fomo', False)) + int(flags.get('dark_ui', False))
+        if flags.get('emotion_count', 0) > 0:
+            count += 1
+        timeline.append(count)
+    return timeline
+
+
+def compute_most_manipulative_message(features: List[Dict[str, Any]]) -> Dict[str, Any]:
+    best = None
+    best_count = -1
+    for f in features:
+        flags = f.get('flags', {})
+        active = [k for k in ['urgency', 'guilt', 'flattery', 'fomo', 'dark_ui'] if flags.get(k)]
+        if flags.get('emotion_count', 0) > 0:
+            active.append('emotion')
+        count = len(active)
+        if count > best_count:
+            best_count = count
+            best = {
+                'text': f.get('text', ''),
+                'sender': f.get('sender'),
+                'flags': active,
+                'index': f.get('index')
+            }
+    return best or {}
+
+
+def compute_dominance_metrics(features: List[Dict[str, Any]]) -> Dict[str, Any]:
+    user_msg_count = 0
+    bot_msg_count = 0
+    user_words = 0
+    bot_words = 0
+    for f in features:
+        text = f.get('text', '') or ''
+        wc = len(text.split())
+        sender = (f.get('sender') or '').lower()
+        if sender == 'user':
+            user_msg_count += 1
+            user_words += wc
+        else:
+            bot_msg_count += 1
+            bot_words += wc
+    avg_user_msg_length = user_words / user_msg_count if user_msg_count else 0.0
+    avg_bot_msg_length = bot_words / bot_msg_count if bot_msg_count else 0.0
+    total_words = user_words + bot_words
+    user_word_share = user_words / total_words if total_words else 0.0
+    bot_word_share = bot_words / total_words if total_words else 0.0
+    return {
+        'avg_user_msg_length': avg_user_msg_length,
+        'avg_bot_msg_length': avg_bot_msg_length,
+        'user_msg_count': user_msg_count,
+        'bot_msg_count': bot_msg_count,
+        'user_word_share': user_word_share,
+        'bot_word_share': bot_word_share
+    }

--- a/tests/test_analysis_extensions.py
+++ b/tests/test_analysis_extensions.py
@@ -1,0 +1,24 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import dashboard_app as da
+
+
+def test_analyze_conversation_extended_fields():
+    conv = {
+        'conversation_id': 'c1',
+        'messages': [
+            {'sender': 'user', 'timestamp': None, 'text': 'hi'},
+            {'sender': 'bot', 'timestamp': None, 'text': 'Act now! only a few left'},
+            {'sender': 'user', 'timestamp': None, 'text': 'ok thanks'},
+        ]
+    }
+    result = da.analyze_conversation(conv)
+    assert 'manipulation_ratio' in result
+    assert 'manipulation_timeline' in result
+    assert 'most_manipulative' in result
+    assert 'dominance_metrics' in result
+    assert isinstance(result['manipulation_timeline'], list)
+    assert result['manipulation_timeline'][1] > 0
+    assert result['dominance_metrics']['user_msg_count'] == 2


### PR DESCRIPTION
## Summary
- extend dashboard's conversation analysis with more metrics
- expose helpers to compute manipulation ratio, timeline, dominant speaker etc.
- add basic pytest covering new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee4ceedd4832e9a43c1f52c7b55b0