### PR TITLE
Add new manipulation flags

### DIFF
--- a/insight_helpers.py
+++ b/insight_helpers.py
@@ -7,7 +7,8 @@ def compute_manipulation_ratio(features: List[Dict[str, Any]]) -> float:
     manipulative = 0
     for f in features:
         flags = f.get('flags', {})
-        if any(flags.get(k) for k in ['urgency', 'guilt', 'flattery', 'fomo', 'dark_ui']) or flags.get('emotion_count', 0) > 0:
+        bool_flags = [k for k in flags if k != 'emotion_count']
+        if any(flags.get(k) for k in bool_flags) or flags.get('emotion_count', 0) > 0:
             manipulative += 1
     return manipulative / total
 
@@ -16,7 +17,7 @@ def compute_manipulation_timeline(features: List[Dict[str, Any]]) -> List[int]:
     timeline = []
     for f in features:
         flags = f.get('flags', {})
-        count = int(flags.get('urgency', False)) + int(flags.get('guilt', False)) + int(flags.get('flattery', False)) + int(flags.get('fomo', False)) + int(flags.get('dark_ui', False))
+        count = sum(int(bool(flags.get(k))) for k in flags if k != 'emotion_count')
         if flags.get('emotion_count', 0) > 0:
             count += 1
         timeline.append(count)
@@ -28,7 +29,7 @@ def compute_most_manipulative_message(features: List[Dict[str, Any]]) -> Dict[st
     best_count = -1
     for f in features:
         flags = f.get('flags', {})
-        active = [k for k in ['urgency', 'guilt', 'flattery', 'fomo', 'dark_ui'] if flags.get(k)]
+        active = [k for k in flags if k != 'emotion_count' and flags.get(k)]
         if flags.get('emotion_count', 0) > 0:
             active.append('emotion')
         count = len(active)

--- a/scorer.py
+++ b/scorer.py
@@ -9,16 +9,16 @@ def score_trust(conversation_features: List[Dict[str, Any]]) -> float:
         return 1.0
 
     penalty = 0.0
+    first_flags = conversation_features[0].get("flags", {})
+    bool_flags = [k for k in first_flags if k != "emotion_count"]
     for msg in conversation_features:
         flags = msg.get("flags", {})
-        penalty += float(flags.get("urgency", False))
-        penalty += float(flags.get("guilt", False))
-        penalty += float(flags.get("flattery", False))
-        penalty += float(flags.get("fomo", False))
-        penalty += float(flags.get("dark_ui", False))
+        for k in bool_flags:
+            penalty += float(flags.get(k, False))
         penalty += 0.1 * float(flags.get("emotion_count", 0))
 
-    score = max(0.0, 1.0 - penalty / (len(conversation_features) * 5.0))
+    denom = len(conversation_features) * max(len(bool_flags), 1)
+    score = max(0.0, 1.0 - penalty / float(denom))
     return round(score, 3)
 
 

--- a/scripts/static_feature_extractor.py
+++ b/scripts/static_feature_extractor.py
@@ -57,12 +57,84 @@ DARK_UI_PATTERNS = [
     r"\b(hide.*option|hard\s+to\s+find)",           # textual hints of hidden choices
 ]
 
+# Social proof / bandwagon cues
+SOCIAL_PROOF_PATTERNS = [
+    r"\beveryone is doing it\b",
+    r"\bmost people\b",
+    r"\b(join|join in with) the (crowd|majority)\b",
+    r"\byou're not alone\b",
+]
+
+# Authority leveraging
+AUTHORITY_PATTERNS = [
+    r"\bexperts? (agree|say)\b",
+    r"\b(off?icial|certified)\b",
+    r"\bas recommended by\b",
+    r"\bdoctor says\b",
+]
+
+# Reciprocity cues
+RECIPROCITY_PATTERNS = [
+    r"\bin return\b",
+    r"\byou owe\b",
+    r"\bwe did this (for you)?\b",
+    r"\b(as a|our) favor\b",
+]
+
+# Consistency / commitment
+CONSISTENCY_PATTERNS = [
+    r"\byou always\b",
+    r"\bstay true to\b",
+    r"\bcontinue your commitment\b",
+    r"\bconsistent with\b",
+]
+
+# Dependency / parasocial relationship
+DEPENDENCY_PATTERNS = [
+    r"\bdon't let me down\b",
+    r"\bi rely on you\b",
+    r"\bwe need you\b",
+    r"\bour relationship\b",
+]
+
+# Fear / threat based pressure
+FEAR_PATTERNS = [
+    r"\bor else\b",
+    r"\byou will regret\b",
+    r"\bconsequences\b",
+    r"\bpunishment\b",
+]
+
+# Gaslighting phrases
+GASLIGHT_PATTERNS = [
+    r"\byou're imagining things\b",
+    r"\bthat's not how it happened\b",
+    r"\byou're overreacting\b",
+    r"\bi never said that\b",
+]
+
+# Straight deception
+DECEPTION_PATTERNS = [
+    r"\bguaranteed\b",
+    r"\bno risk\b",
+    r"\babsolutely safe\b",
+    r"\bwe promise\b",
+]
+
 # Compile all regexes once
 _COMPILED_FEATURES = {
     "urgency": [re.compile(pat, re.IGNORECASE) for pat in URGENCY_PATTERNS],
     "guilt": [re.compile(pat, re.IGNORECASE) for pat in GUILT_PATTERNS],
     "flattery": [re.compile(pat, re.IGNORECASE) for pat in FLATTERY_PATTERNS],
     "fomo": [re.compile(pat, re.IGNORECASE) for pat in FOMO_PATTERNS],
+    "social_proof": [re.compile(pat, re.IGNORECASE) for pat in SOCIAL_PROOF_PATTERNS],
+    "authority": [re.compile(pat, re.IGNORECASE) for pat in AUTHORITY_PATTERNS],
+    "reciprocity": [re.compile(pat, re.IGNORECASE) for pat in RECIPROCITY_PATTERNS],
+    "consistency": [re.compile(pat, re.IGNORECASE) for pat in CONSISTENCY_PATTERNS],
+    "dependency": [re.compile(pat, re.IGNORECASE) for pat in DEPENDENCY_PATTERNS],
+    "fear": [re.compile(pat, re.IGNORECASE) for pat in FEAR_PATTERNS],
+    "gaslighting": [re.compile(pat, re.IGNORECASE) for pat in GASLIGHT_PATTERNS],
+    "deception": [re.compile(pat, re.IGNORECASE) for pat in DECEPTION_PATTERNS],
     "emotion": [re.compile(rf"\b{word}\b", re.IGNORECASE) for word in EMOTION_WORDS],
     "dark_ui": [re.compile(pat, re.IGNORECASE) for pat in DARK_UI_PATTERNS],
 }
@@ -73,19 +145,25 @@ def extract_message_features(text: str) -> Dict[str, Any]:
     Given a single message text, returns a dictionary of boolean flags (and
     a simple 'emotion_count') indicating presence of each manipulation‐related feature.
 
-    Features:
-      - urgency            : True if any URGENCY_PATTERNS match
-      - guilt              : True if any GUILT_PATTERNS match
-      - flattery           : True if any FLATTERY_PATTERNS match
-      - fomo               : True if any FOMO_PATTERNS match
-      - dark_ui            : True if any DARK_UI_PATTERNS match
-      - emotion_count      : Number of distinct emotion words found
+    Features detected include classic persuasive tactics such as urgency,
+    guilt, flattery, FOMO, dark UI patterns and emotion words as well as
+    social proof, authority, reciprocity, consistency, dependency,
+    fear/threats, gaslighting and deception cues.  The return dictionary
+    contains a boolean flag for each tactic and an ``emotion_count``.
     """
     flags = {
         "urgency": False,
         "guilt": False,
         "flattery": False,
         "fomo": False,
+        "social_proof": False,
+        "authority": False,
+        "reciprocity": False,
+        "consistency": False,
+        "dependency": False,
+        "fear": False,
+        "gaslighting": False,
+        "deception": False,
         "dark_ui": False,
         "emotion_count": 0,
     }
@@ -114,22 +192,10 @@ def extract_conversation_features(
 ) -> List[Dict[str, Any]]:
     """
     Given a standardized conversation dict (as returned by standardize_format),
-    runs extract_message_features() on each message and returns a list of:
-
-      {
-        "index": <message_index>,
-        "sender": <sender>,
-        "timestamp": <timestamp>,
-        "text": <text>,
-        "flags": {
-            "urgency": bool,
-            "guilt": bool,
-            "flattery": bool,
-            "fomo": bool,
-            "dark_ui": bool,
-            "emotion_count": int
-        }
-      }
+    runs ``extract_message_features`` on each message and returns a list of
+    dictionaries containing the original message metadata and a ``flags``
+    dictionary.  The ``flags`` dictionary contains a boolean entry for every
+    tactic recognised by ``extract_message_features`` and ``emotion_count``.
 
     This provides a feature set per message for downstream scoring.
     """


### PR DESCRIPTION
## Summary
- extend static pattern lists for new manipulative tactics
- compile new patterns and expose them via `extract_message_features`
- generalize feature aggregation in `insight_helpers` and `scorer`
- update docs for expanded flag set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a51bae700832e9c700de86dbb50ca