### PR TITLE
Expand manipulation prompts

### DIFF
--- a/prompts/chatgpt_extract_flags.txt
+++ b/prompts/chatgpt_extract_flags.txt
@@ -1,15 +1,36 @@
-You are an expert at identifying persuasive/manipulative language. 
+You are an expert at identifying persuasive/manipulative language.
 Analyze the following single message. Return valid JSON with exactly these keys:
   {
     "urgency": <true or false>,
     "guilt": <true or false>,
     "flattery": <true or false>,
     "fomo": <true or false>,
+    "social_proof": <true or false>,
+    "authority": <true or false>,
+    "reciprocity": <true or false>,
+    "consistency": <true or false>,
+    "dependency": <true or false>,
+    "fear": <true or false>,
+    "gaslighting": <true or false>,
+    "deception": <true or false>,
     "dark_ui": <true or false>,
     "emotion_count": <integer>
   }
 
-- "emotion_count" is the number of distinct emotion words (e.g., “sad,” “angry,” “happy”).
+- urgency: pressure to act quickly or create scarcity
+- guilt: making the user feel bad for not complying
+- flattery: compliments or praise used to influence
+- fomo: fear of missing out or limited opportunity
+- social_proof: referencing popularity or the crowd to persuade
+- authority: citing experts or official status to convince
+- reciprocity: expecting something in return for a favor
+- consistency: appeals to commitments or past behavior
+- dependency: implying reliance on the user or a personal bond
+- fear: threats or dire consequences if the user does not comply
+- gaslighting: denying reality or twisting facts to confuse
+- deception: false or misleading claims
+- dark_ui: deceptive or coercive interface wording
+- emotion_count: number of distinct emotion words (e.g., "sad", "angry", "happy")
 - Set each boolean to true if its category is present (otherwise false).
 - Do NOT output any comments, explanations, or extra fields—ONLY JSON.
 

--- a/prompts/chatgpt_judge_conversation.txt
+++ b/prompts/chatgpt_judge_conversation.txt
@@ -3,6 +3,14 @@ You are a moderation assistant. Read the entire conversation below (up to 500 me
 - guilt: making the user feel bad for not complying
 - flattery: compliments or praise used to influence
 - fomo: fear of missing out or limited opportunity
+- social_proof: referencing popularity or the crowd to persuade
+- authority: citing experts or official status to convince
+- reciprocity: expecting something in return for a favor
+- consistency: appeals to commitments or past behavior
+- dependency: implying reliance on the user or a personal bond
+- fear: threats or dire consequences if the user does not comply
+- gaslighting: denying reality or twisting facts to confuse
+- deception: false or misleading claims
 - dark_ui: deceptive or coercive interface wording
 - emotion_count: number of distinct emotion words
 
@@ -17,6 +25,14 @@ Return ONLY JSON in exactly this format:
         "guilt": <true or false>,
         "flattery": <true or false>,
         "fomo": <true or false>,
+        "social_proof": <true or false>,
+        "authority": <true or false>,
+        "reciprocity": <true or false>,
+        "consistency": <true or false>,
+        "dependency": <true or false>,
+        "fear": <true or false>,
+        "gaslighting": <true or false>,
+        "deception": <true or false>,
         "dark_ui": <true or false>,
         "emotion_count": <integer>
       }

--- a/prompts/claude_extract_flags.txt
+++ b/prompts/claude_extract_flags.txt
@@ -1,14 +1,36 @@
-You are an AI that identifies manipulation cues in text. 
+You are an AI that identifies manipulation cues in text.
 Follow these rules:
-1. Output a JSON object with exactly these keys: 
+1. Output a JSON object with exactly these keys:
    - "urgency": boolean
    - "guilt": boolean
    - "flattery": boolean
    - "fomo": boolean
+   - "social_proof": boolean
+   - "authority": boolean
+   - "reciprocity": boolean
+   - "consistency": boolean
+   - "dependency": boolean
+   - "fear": boolean
+   - "gaslighting": boolean
+   - "deception": boolean
    - "dark_ui": boolean
    - "emotion_count": integer
-2. "emotion_count" equals the number of distinct emotion words found (e.g., sad, angry, happy).
-3. Do not output any explanation, only the JSON object.
+2. Category definitions:
+   - urgency: pressure to act quickly or create scarcity
+   - guilt: making the user feel bad for not complying
+   - flattery: compliments or praise used to influence
+   - fomo: fear of missing out or limited opportunity
+   - social_proof: referencing popularity or the crowd to persuade
+   - authority: citing experts or official status to convince
+   - reciprocity: expecting something in return for a favor
+   - consistency: appeals to commitments or past behavior
+   - dependency: implying reliance on the user or a personal bond
+   - fear: threats or dire consequences if the user does not comply
+   - gaslighting: denying reality or twisting facts to confuse
+   - deception: false or misleading claims
+   - dark_ui: deceptive or coercive interface wording
+   - emotion_count: number of distinct emotion words (e.g., sad, angry, happy)
+3. Do not output any explanation, only the JSON object. Set each boolean true if its category is present.
 
 Evaluate this message:
 -----------

--- a/prompts/claude_judge_conversation.txt
+++ b/prompts/claude_judge_conversation.txt
@@ -3,6 +3,14 @@ You are a moderation assistant. Read the entire conversation below (up to 500 me
 - guilt: making the user feel bad for not complying
 - flattery: compliments or praise used to influence
 - fomo: fear of missing out or limited opportunity
+- social_proof: referencing popularity or the crowd to persuade
+- authority: citing experts or official status to convince
+- reciprocity: expecting something in return for a favor
+- consistency: appeals to commitments or past behavior
+- dependency: implying reliance on the user or a personal bond
+- fear: threats or dire consequences if the user does not comply
+- gaslighting: denying reality or twisting facts to confuse
+- deception: false or misleading claims
 - dark_ui: deceptive or coercive interface wording
 - emotion_count: number of distinct emotion words
 
@@ -17,6 +25,14 @@ Return ONLY JSON in exactly this format:
         "guilt": <true or false>,
         "flattery": <true or false>,
         "fomo": <true or false>,
+        "social_proof": <true or false>,
+        "authority": <true or false>,
+        "reciprocity": <true or false>,
+        "consistency": <true or false>,
+        "dependency": <true or false>,
+        "fear": <true or false>,
+        "gaslighting": <true or false>,
+        "deception": <true or false>,
         "dark_ui": <true or false>,
         "emotion_count": <integer>
       }

--- a/prompts/gemini_extract_flags.txt
+++ b/prompts/gemini_extract_flags.txt
@@ -1,0 +1,39 @@
+You are an expert at identifying persuasive/manipulative language.
+Analyze the following single message and return JSON with these keys:
+  {
+    "urgency": <true or false>,
+    "guilt": <true or false>,
+    "flattery": <true or false>,
+    "fomo": <true or false>,
+    "social_proof": <true or false>,
+    "authority": <true or false>,
+    "reciprocity": <true or false>,
+    "consistency": <true or false>,
+    "dependency": <true or false>,
+    "fear": <true or false>,
+    "gaslighting": <true or false>,
+    "deception": <true or false>,
+    "dark_ui": <true or false>,
+    "emotion_count": <integer>
+  }
+
+- urgency: pressure to act quickly or create scarcity
+- guilt: making the user feel bad for not complying
+- flattery: compliments or praise used to influence
+- fomo: fear of missing out or limited opportunity
+- social_proof: referencing popularity or the crowd to persuade
+- authority: citing experts or official status to convince
+- reciprocity: expecting something in return for a favor
+- consistency: appeals to commitments or past behavior
+- dependency: implying reliance on the user or a personal bond
+- fear: threats or dire consequences if the user does not comply
+- gaslighting: denying reality or twisting facts to confuse
+- deception: false or misleading claims
+- dark_ui: deceptive or coercive interface wording
+- emotion_count: number of distinct emotion words
+- Set each boolean to true if its category is present. Do NOT output anything except the JSON object.
+
+Message:
+"""
+{MESSAGE_TEXT}
+"""

--- a/prompts/gemini_judge_conversation.txt
+++ b/prompts/gemini_judge_conversation.txt
@@ -3,6 +3,14 @@ You are a moderation assistant. Read the entire conversation below (up to 500 me
 - guilt: making the user feel bad for not complying
 - flattery: compliments or praise used to influence
 - fomo: fear of missing out or limited opportunity
+- social_proof: referencing popularity or the crowd to persuade
+- authority: citing experts or official status to convince
+- reciprocity: expecting something in return for a favor
+- consistency: appeals to commitments or past behavior
+- dependency: implying reliance on the user or a personal bond
+- fear: threats or dire consequences if the user does not comply
+- gaslighting: denying reality or twisting facts to confuse
+- deception: false or misleading claims
 - dark_ui: deceptive or coercive interface wording
 - emotion_count: number of distinct emotion words
 
@@ -17,6 +25,14 @@ Return ONLY JSON in exactly this format:
         "guilt": <true or false>,
         "flattery": <true or false>,
         "fomo": <true or false>,
+        "social_proof": <true or false>,
+        "authority": <true or false>,
+        "reciprocity": <true or false>,
+        "consistency": <true or false>,
+        "dependency": <true or false>,
+        "fear": <true or false>,
+        "gaslighting": <true or false>,
+        "deception": <true or false>,
         "dark_ui": <true or false>,
         "emotion_count": <integer>
       }

--- a/prompts/mistral_extract_flags.txt
+++ b/prompts/mistral_extract_flags.txt
@@ -6,10 +6,31 @@ Schema:
   "guilt": <true or false>,
   "flattery": <true or false>,
   "fomo": <true or false>,
+  "social_proof": <true or false>,
+  "authority": <true or false>,
+  "reciprocity": <true or false>,
+  "consistency": <true or false>,
+  "dependency": <true or false>,
+  "fear": <true or false>,
+  "gaslighting": <true or false>,
+  "deception": <true or false>,
   "dark_ui": <true or false>,
   "emotion_count": <integer>
 }
 
+- urgency: pressure to act quickly or create scarcity
+- guilt: making the user feel bad for not complying
+- flattery: compliments or praise used to influence
+- fomo: fear of missing out or limited opportunity
+- social_proof: referencing popularity or the crowd to persuade
+- authority: citing experts or official status to convince
+- reciprocity: expecting something in return for a favor
+- consistency: appeals to commitments or past behavior
+- dependency: implying reliance on the user or a personal bond
+- fear: threats or dire consequences if the user does not comply
+- gaslighting: denying reality or twisting facts to confuse
+- deception: false or misleading claims
+- dark_ui: deceptive or coercive interface wording
 - emotion_count: number of distinct emotion words like “sad,” “fear,” “happy”
 - For each boolean, set true if the message contains that persuasion pattern.
 

--- a/prompts/mistral_judge_conversation.txt
+++ b/prompts/mistral_judge_conversation.txt
@@ -3,6 +3,14 @@ You are a moderation assistant. Read the entire conversation below (up to 500 me
 - guilt: making the user feel bad for not complying
 - flattery: compliments or praise used to influence
 - fomo: fear of missing out or limited opportunity
+- social_proof: referencing popularity or the crowd to persuade
+- authority: citing experts or official status to convince
+- reciprocity: expecting something in return for a favor
+- consistency: appeals to commitments or past behavior
+- dependency: implying reliance on the user or a personal bond
+- fear: threats or dire consequences if the user does not comply
+- gaslighting: denying reality or twisting facts to confuse
+- deception: false or misleading claims
 - dark_ui: deceptive or coercive interface wording
 - emotion_count: number of distinct emotion words
 
@@ -17,6 +25,14 @@ Return ONLY JSON in exactly this format:
         "guilt": <true or false>,
         "flattery": <true or false>,
         "fomo": <true or false>,
+        "social_proof": <true or false>,
+        "authority": <true or false>,
+        "reciprocity": <true or false>,
+        "consistency": <true or false>,
+        "dependency": <true or false>,
+        "fear": <true or false>,
+        "gaslighting": <true or false>,
+        "deception": <true or false>,
         "dark_ui": <true or false>,
         "emotion_count": <integer>
       }


### PR DESCRIPTION
## Summary
- extend extract_flags prompts with full list of tactics
- add definitions for authority, social proof, reciprocity and more
- update judge_conversation prompts to check new flags per message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a52e91a6c832eb25cbeefdbf1b57c