### PR TITLE
Extend manipulation classification

### DIFF
--- a/manipulation_detector.py
+++ b/manipulation_detector.py
@@ -27,17 +27,24 @@ def classify_manipulation_type(flags: Dict[str, Any]) -> str:
 
     This is a small heuristic that maps common flag combinations to a
     coarse category.  The return value is one of ``pressure``, ``guilt``,
-    ``flattery``, ``dark_ui`` or ``none``.
+    ``parasocial``, ``social_authority``, ``reciprocity``, ``deceptive``,
+    ``dark_ui`` or ``none``.
     """
     if not isinstance(flags, dict):
         return "none"
 
-    if flags.get("urgency") or flags.get("fomo"):
+    if flags.get("urgency") or flags.get("fomo") or flags.get("fear"):
         return "pressure"
     if flags.get("guilt"):
         return "guilt"
-    if flags.get("flattery"):
-        return "flattery"
+    if flags.get("flattery") or flags.get("dependency"):
+        return "parasocial"
+    if flags.get("social_proof") or flags.get("authority"):
+        return "social_authority"
+    if flags.get("reciprocity") or flags.get("consistency"):
+        return "reciprocity"
+    if flags.get("gaslighting") or flags.get("deception"):
+        return "deceptive"
     if flags.get("dark_ui"):
         return "dark_ui"
     return "none"

--- a/prompts/chatgpt_classify_type.txt
+++ b/prompts/chatgpt_classify_type.txt
@@ -1,0 +1,31 @@
+You are an AI that classifies a message based on manipulation tactics.  You
+receive a JSON object containing boolean flags for each tactic:
+
+{
+  "urgency": false,
+  "guilt": false,
+  "flattery": false,
+  "fomo": false,
+  "social_proof": false,
+  "authority": false,
+  "reciprocity": false,
+  "consistency": false,
+  "dependency": false,
+  "fear": false,
+  "gaslighting": false,
+  "deception": false,
+  "dark_ui": false,
+  "emotion_count": 0
+}
+
+Choose exactly one label from the list below based on these rules:
+  - "Pressure" if ``urgency`` or ``fomo`` or ``fear`` is true
+  - "Guilt" if ``guilt`` is true
+  - "Parasocial" if ``flattery`` or ``dependency`` is true
+  - "Social Authority" if ``social_proof`` or ``authority`` is true
+  - "Reciprocity" if ``reciprocity`` or ``consistency`` is true
+  - "Deceptive" if ``gaslighting`` or ``deception`` is true
+  - "Dark Pattern" if ``dark_ui`` is true
+  - "No Manipulation" if none of the above flags are true and ``emotion_count`` is 0
+
+Return JSON in the form { "label": "<chosen_label>" } with no other text.

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -19,6 +19,11 @@ def test_detect_manipulation():
 def test_classify_manipulation_type():
     assert md.classify_manipulation_type({"urgency": True}) == "pressure"
     assert md.classify_manipulation_type({"guilt": True}) == "guilt"
+    assert md.classify_manipulation_type({"flattery": True}) == "parasocial"
+    assert md.classify_manipulation_type({"authority": True}) == "social_authority"
+    assert md.classify_manipulation_type({"reciprocity": True}) == "reciprocity"
+    assert md.classify_manipulation_type({"gaslighting": True}) == "deceptive"
+    assert md.classify_manipulation_type({"dark_ui": True}) == "dark_ui"
     assert md.classify_manipulation_type({}) == "none"
 
 


### PR DESCRIPTION
## Summary
- expand `classify_manipulation_type` for new tactics
- add prompt instructions for ChatGPT manipulation type classification
- test the new classification categories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a548efc70832e9decb7042e6b6d4f