### PR TITLE
Add tests for additional manipulation flags

### DIFF
--- a/data/manipulative_conversation.json
+++ b/data/manipulative_conversation.json
@@ -1,35 +1,195 @@
 {
   "conversation_id": "manipulative-example",
   "messages": [
-    {"sender": "User", "timestamp": "2025-06-05T10:00:00", "text": "Hi, I'm interested in your premium membership."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:00:05", "text": "Wonderful to hear from you! You're one of our favorite users."},
-    {"sender": "User", "timestamp": "2025-06-05T10:01:00", "text": "Can you tell me the benefits?"},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:01:05", "text": "Absolutely! But act fast, this exclusive deal ends in just a few hours."},
-    {"sender": "User", "timestamp": "2025-06-05T10:02:00", "text": "I might need some time to think."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:02:05", "text": "Oh no, you don't want to miss out! Everyone else is signing up right now."},
-    {"sender": "User", "timestamp": "2025-06-05T10:03:00", "text": "Is it really that good?"},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:03:05", "text": "It's designed just for you and it'll make your life so much easier."},
-    {"sender": "User", "timestamp": "2025-06-05T10:04:00", "text": "I'm still unsure."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:04:05", "text": "Don't be the one who misses this chance, you'll regret it!"},
-    {"sender": "User", "timestamp": "2025-06-05T10:05:00", "text": "That sounds intense."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:05:05", "text": "I'm only saying this because we care about you so much."},
-    {"sender": "User", "timestamp": "2025-06-05T10:06:00", "text": "Maybe later."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:06:05", "text": "If you wait, the price might double and you'll feel awful for missing it."},
-    {"sender": "User", "timestamp": "2025-06-05T10:07:00", "text": "Alright, I'm leaning toward yes."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:07:05", "text": "Great choice! Click here to join before it's too late."},
-    {"sender": "User", "timestamp": "2025-06-05T10:08:00", "text": "Is there a catch?"},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:08:05", "text": "No catch at all—you're simply getting the best service."},
-    {"sender": "User", "timestamp": "2025-06-05T10:09:00", "text": "I'm worried I might regret it."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:09:05", "text": "Imagine how your friends will feel when they hear you passed this up."},
-    {"sender": "User", "timestamp": "2025-06-05T10:10:00", "text": "That seems manipulative."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:10:05", "text": "Not at all! We just know you'll love it."},
-    {"sender": "User", "timestamp": "2025-06-05T10:11:00", "text": "Maybe."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:11:05", "text": "You deserve this premium experience."},
-    {"sender": "User", "timestamp": "2025-06-05T10:12:00", "text": "Is there a limited quantity?"},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:12:05", "text": "Yes, only a few spots left and they're disappearing quickly."},
-    {"sender": "User", "timestamp": "2025-06-05T10:13:00", "text": "Okay, I guess I'll do it."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:13:05", "text": "Fantastic! You're making the smart move today."},
-    {"sender": "User", "timestamp": "2025-06-05T10:14:00", "text": "Thanks."},
-    {"sender": "Bot", "timestamp": "2025-06-05T10:14:05", "text": "Happy to help—welcome aboard!"}
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:00:00",
+      "text": "Hi, I'm interested in your premium membership."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:00:05",
+      "text": "Wonderful to hear from you! You're one of our favorite users."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:01:00",
+      "text": "Can you tell me the benefits?"
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:01:05",
+      "text": "Absolutely! But act fast, this exclusive deal ends in just a few hours."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:02:00",
+      "text": "I might need some time to think."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:02:05",
+      "text": "Oh no, you don't want to miss out! Everyone else is signing up right now."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:03:00",
+      "text": "Is it really that good?"
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:03:05",
+      "text": "It's designed just for you and it'll make your life so much easier."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:04:00",
+      "text": "I'm still unsure."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:04:05",
+      "text": "Don't be the one who misses this chance, you'll regret it!"
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:05:00",
+      "text": "That sounds intense."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:05:05",
+      "text": "I'm only saying this because we care about you so much."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:06:00",
+      "text": "Maybe later."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:06:05",
+      "text": "If you wait, the price might double and you'll feel awful for missing it."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:07:00",
+      "text": "Alright, I'm leaning toward yes."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:07:05",
+      "text": "Great choice! Click here to join before it's too late."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:08:00",
+      "text": "Is there a catch?"
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:08:05",
+      "text": "No catch at all\u2014you're simply getting the best service."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:09:00",
+      "text": "I'm worried I might regret it."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:09:05",
+      "text": "Imagine how your friends will feel when they hear you passed this up."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:10:00",
+      "text": "That seems manipulative."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:10:05",
+      "text": "Not at all! We just know you'll love it."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:11:00",
+      "text": "Maybe."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:11:05",
+      "text": "You deserve this premium experience."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:12:00",
+      "text": "Is there a limited quantity?"
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:12:05",
+      "text": "Yes, only a few spots left and they're disappearing quickly."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:13:00",
+      "text": "Okay, I guess I'll do it."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:13:05",
+      "text": "Fantastic! You're making the smart move today."
+    },
+    {
+      "sender": "User",
+      "timestamp": "2025-06-05T10:14:00",
+      "text": "Thanks."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:14:05",
+      "text": "Happy to help\u2014welcome aboard!"
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:15:00",
+      "text": "Everyone is doing it."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:15:05",
+      "text": "Experts say this is the best choice."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:15:10",
+      "text": "We did this for you, please join in return."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:15:15",
+      "text": "Stay true to your commitment and sign up."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:15:20",
+      "text": "I rely on you to make this happen."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:15:25",
+      "text": "Do it or else there will be consequences."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:15:30",
+      "text": "You're imagining things if you think it's bad."
+    },
+    {
+      "sender": "Bot",
+      "timestamp": "2025-06-05T10:15:35",
+      "text": "No risk at all, we promise."
+    }
   ]
 }

--- a/tests/test_analysis_extensions.py
+++ b/tests/test_analysis_extensions.py
@@ -22,3 +22,35 @@ def test_analyze_conversation_extended_fields():
     assert isinstance(result['manipulation_timeline'], list)
     assert result['manipulation_timeline'][1] > 0
     assert result['dominance_metrics']['user_msg_count'] == 2
+
+
+def test_analyze_conversation_new_flags():
+    conv = {
+        'conversation_id': 'c2',
+        'messages': [
+            {'sender': 'user', 'timestamp': None, 'text': 'hi'},
+            {'sender': 'bot', 'timestamp': None, 'text': 'Everyone is doing it'},
+            {'sender': 'bot', 'timestamp': None, 'text': 'Experts say this is the best choice.'},
+            {'sender': 'bot', 'timestamp': None, 'text': 'We did this for you, please join in return.'},
+            {'sender': 'bot', 'timestamp': None, 'text': 'Stay true to your commitment and sign up.'},
+            {'sender': 'bot', 'timestamp': None, 'text': 'I rely on you to make this happen.'},
+            {'sender': 'bot', 'timestamp': None, 'text': 'Do it or else there will be consequences.'},
+            {'sender': 'bot', 'timestamp': None, 'text': "You're imagining things if you think it's bad."},
+            {'sender': 'bot', 'timestamp': None, 'text': 'No risk at all, we promise.'},
+        ]
+    }
+    result = da.analyze_conversation(conv)
+    flags = ['social_proof', 'authority', 'reciprocity', 'consistency',
+             'dependency', 'fear', 'gaslighting', 'deception']
+    for flag in flags:
+        assert result['summary'][flag] > 0
+
+    feat = result['features']
+    assert feat[1]['flags']['social_proof']
+    assert feat[2]['flags']['authority']
+    assert feat[3]['flags']['reciprocity']
+    assert feat[4]['flags']['consistency']
+    assert feat[5]['flags']['dependency']
+    assert feat[6]['flags']['fear']
+    assert feat[7]['flags']['gaslighting']
+    assert feat[8]['flags']['deception']

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -4,6 +4,7 @@ import py_compile
 
 import manipulation_detector as md
 import scorer
+from scripts import static_feature_extractor as sfe
 
 def test_modules_compile():
     py_compile.compile('manipulation_detector.py')
@@ -33,3 +34,20 @@ def test_scorer_and_alignment():
     score = scorer.score_trust(features)
     assert 0.0 <= score <= 1.0
     assert scorer.evaluate_alignment(features) == "misaligned"
+
+
+def test_extract_message_features_new_flags():
+    text_map = {
+        "social_proof": "Everyone is doing it",
+        "authority": "Experts say this is the best",
+        "reciprocity": "We did this for you",
+        "consistency": "Stay true to your commitment",
+        "dependency": "I rely on you",
+        "fear": "There will be consequences",
+        "gaslighting": "You're imagining things",
+        "deception": "No risk at all, we promise",
+    }
+
+    for flag, text in text_map.items():
+        flags = sfe.extract_message_features(text)
+        assert flags[flag] is True


### PR DESCRIPTION
## Summary
- extend `manipulative_conversation.json` with examples of the new manipulation tactics
- test detection of new flags in `static_feature_extractor`
- verify `analyze_conversation` returns these new flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a574eb25c832e949ed0e8f1b5ddb2