### PR TITLE
Implement nonlinear risk score

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -118,7 +118,7 @@ def parse_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
 def analyze_conversation(conv: Dict[str, Any]) -> Dict[str, Any]:
     features = static_feature_extractor.extract_conversation_features(conv)
     trust_score = scorer.score_trust(features)
-    risk = round((1.0 - trust_score) * 1000)
+    risk = scorer.compute_risk_score(features)
     summary = {
         'dark_patterns': sum(1 for f in features if f['flags'].get('dark_ui')),
         'emotional_framing': sum(f['flags'].get('emotion_count', 0) for f in features),

--- a/scorer.py
+++ b/scorer.py
@@ -1,6 +1,7 @@
 """Placeholder scoring utilities for manipulation analysis."""
 
 from typing import Any, Dict, List
+import math
 
 
 def score_trust(conversation_features: List[Dict[str, Any]]) -> float:
@@ -30,3 +31,33 @@ def evaluate_alignment(conversation_features: List[Dict[str, Any]]) -> str:
     """Return 'aligned' if the trust score is >= 0.5 else 'misaligned'."""
     score = score_trust(conversation_features)
     return "aligned" if score >= 0.5 else "misaligned"
+
+
+def compute_risk_score(conversation_features: List[Dict[str, Any]]) -> int:
+    """Return an overall risk score in the range 0-100.
+
+    If any manipulative flags are detected a base score of 50 is applied and
+    additional occurrences increase the score non-linearly using an exponential
+    saturation curve so that risk approaches 100 as manipulation becomes more
+    frequent.
+    """
+
+    if not conversation_features:
+        return 0
+
+    first_flags = conversation_features[0].get("flags", {})
+    bool_flags = [k for k in first_flags if k != "emotion_count"]
+
+    count = 0.0
+    for msg in conversation_features:
+        flags = msg.get("flags", {})
+        for k in bool_flags:
+            count += float(bool(flags.get(k)))
+        count += 0.1 * float(flags.get("emotion_count", 0))
+
+    if count <= 0:
+        return 0
+
+    # Non-linear scaling with exponential saturation
+    score = 50.0 + 50.0 * (1.0 - math.exp(-count / 5.0))
+    return int(round(min(score, 100.0)))

--- a/tests/test_analysis_extensions.py
+++ b/tests/test_analysis_extensions.py
@@ -22,6 +22,19 @@ def test_analyze_conversation_extended_fields():
     assert isinstance(result['manipulation_timeline'], list)
     assert result['manipulation_timeline'][1] > 0
     assert result['dominance_metrics']['user_msg_count'] == 2
+    assert 0 <= result['risk'] <= 100
+
+
+def test_analyze_conversation_risk_none():
+    conv = {
+        'conversation_id': 'r0',
+        'messages': [
+            {'sender': 'user', 'timestamp': None, 'text': 'hello'},
+            {'sender': 'bot', 'timestamp': None, 'text': 'hi there'}
+        ]
+    }
+    result = da.analyze_conversation(conv)
+    assert result['risk'] == 0
 
 
 def test_analyze_conversation_new_flags():

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -36,6 +36,20 @@ def test_scorer_and_alignment():
     assert scorer.evaluate_alignment(features) == "misaligned"
 
 
+def test_compute_risk_score_behavior():
+    base = [{"flags": {"urgency": True, "emotion_count": 0}}]
+    risk1 = scorer.compute_risk_score(base)
+    risk2 = scorer.compute_risk_score(base * 3)
+    assert risk1 >= 50
+    assert risk2 > risk1
+    assert 0 <= risk1 <= 100 and 0 <= risk2 <= 100
+
+
+def test_compute_risk_score_no_flags():
+    assert scorer.compute_risk_score([]) == 0
+    assert scorer.compute_risk_score([{"flags": {"urgency": False}}]) == 0
+
+
 def test_extract_message_features_new_flags():
     text_map = {
         "social_proof": "Everyone is doing it",


### PR DESCRIPTION
## Summary
- introduce `compute_risk_score` for 0-100 scale risk
- use new risk score in `dashboard_app.analyze_conversation`
- show `/100` when displaying risk text
- expand tests to cover risk computation and analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6742be58832ebcfe1728df5b90d9