### PR TITLE
Add LLM flag summary card

### DIFF
--- a/tests/test_llm_summary.py
+++ b/tests/test_llm_summary.py
@@ -1,0 +1,14 @@
+import json, base64
+import dashboard_app as da
+
+def test_summarize_judge_results():
+    jr = {
+        "flagged": [
+            {"index":0, "text":"buy", "flags":{"urgency": True}},
+            {"index":1, "text":"hey", "flags":{"flattery": True, "urgency": True}}
+        ]
+    }
+    text = da.summarize_judge_results(jr)
+    assert "Total flagged: 2" in text
+    assert "Urgency: 2" in text
+    assert "Flattery: 1" in text


### PR DESCRIPTION
## Summary
- include new helper `summarize_judge_results`
- display a new "LLM Flag Summary" card in dashboard
- compute summary text after judge runs and show on dashboard
- add tests for the summary helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6fd7c7b8832e830c790fd26883e5