### PR TITLE
Add LLM timeline series

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -9,6 +9,7 @@ from insight_helpers import (
     compute_manipulation_timeline,
     compute_most_manipulative_message,
     compute_dominance_metrics,
+    compute_llm_flag_timeline,
 )
 
 try:
@@ -560,6 +561,7 @@ def update_output(contents, view_mode, download_clicks, judge_clicks, provider, 
                 mode="lines+markers",
                 line=dict(color="#FADFC9"),
                 hovertemplate="Message %{x} – %{y} manipulation flags",
+                name="Heuristic",
             )
         ],
         layout=go.Layout(
@@ -898,6 +900,17 @@ def update_output(contents, view_mode, download_clicks, judge_clicks, provider, 
                 judge_div = html.Div("No manipulative bot messages detected.", className="text-muted")
 
             summary_text = summarize_judge_results(judge_results)
+            judge_timeline = compute_llm_flag_timeline(judge_results, len(results["features"]))
+            if any(judge_timeline):
+                timeline_fig.add_trace(
+                    go.Scatter(
+                        y=judge_timeline,
+                        mode="markers",
+                        marker=dict(color="#EF553B"),
+                        name="LLM Judge",
+                        hovertemplate="Message %{x} – %{y} flags (LLM)",
+                    )
+                )
 
     download_data = None
     if download_clicks:

--- a/insight_helpers.py
+++ b/insight_helpers.py
@@ -24,6 +24,19 @@ def compute_manipulation_timeline(features: List[Dict[str, Any]]) -> List[int]:
     return timeline
 
 
+def compute_llm_flag_timeline(judge_results: Dict[str, Any], total_messages: int) -> List[int]:
+    """Return counts of LLM-flagged tactics per message index."""
+    timeline = [0] * total_messages
+    if not isinstance(judge_results, dict):
+        return timeline
+    for item in judge_results.get("flagged", []):
+        idx = item.get("index")
+        if isinstance(idx, int) and 0 <= idx < total_messages:
+            flags = item.get("flags", {})
+            timeline[idx] = sum(int(bool(v)) for v in flags.values())
+    return timeline
+
+
 def compute_most_manipulative_message(features: List[Dict[str, Any]]) -> Dict[str, Any]:
     best = None
     best_count = -1

--- a/tests/test_llm_summary.py
+++ b/tests/test_llm_summary.py
@@ -1,4 +1,5 @@
 import json, base64
+import plotly.graph_objs as go
 import dashboard_app as da
 
 def test_summarize_judge_results():
@@ -12,3 +13,17 @@ def test_summarize_judge_results():
     assert "Total flagged: 2" in text
     assert "Urgency: 2" in text
     assert "Flattery: 1" in text
+
+
+def test_judge_timeline_trace():
+    features = [
+        {"index": 0, "sender": "bot", "timestamp": None, "text": "buy", "flags": {"urgency": True}},
+        {"index": 1, "sender": "user", "timestamp": None, "text": "ok", "flags": {}},
+    ]
+    timeline = da.compute_manipulation_timeline(features)
+    judge = {"flagged": [{"index": 0, "text": "buy", "flags": {"urgency": True}}]}
+    jtimeline = da.compute_llm_flag_timeline(judge, len(features))
+    fig = go.Figure([go.Scatter(y=timeline, name="Heuristic")])
+    if any(jtimeline):
+        fig.add_trace(go.Scatter(y=jtimeline, mode="markers", name="LLM Judge"))
+    assert len(fig.data) == 2


### PR DESCRIPTION
## Summary
- compute LLM judge timeline from flagged indices
- plot a second scatter in timeline plot when LLM results are present
- verify new trace creation in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a724417c0832eb42deea6311be299