### PR TITLE
Add flag comparison chart and tests

### DIFF
--- a/tests/test_llm_summary.py
+++ b/tests/test_llm_summary.py
@@ -1,6 +1,6 @@
 import json, base64
-import plotly.graph_objs as go
 import dashboard_app as da
+go = da.go
 
 def test_summarize_judge_results():
     jr = {
@@ -23,7 +23,23 @@ def test_judge_timeline_trace():
     timeline = da.compute_manipulation_timeline(features)
     judge = {"flagged": [{"index": 0, "text": "buy", "flags": {"urgency": True}}]}
     jtimeline = da.compute_llm_flag_timeline(judge, len(features))
-    fig = go.Figure([go.Scatter(y=timeline, name="Heuristic")])
-    if any(jtimeline):
-        fig.add_trace(go.Scatter(y=jtimeline, mode="markers", name="LLM Judge"))
-    assert len(fig.data) == 2
+    assert timeline == [1, 0]
+    assert jtimeline == [1, 0]
+
+
+def test_flag_comparison_figure():
+    features = [
+        {"index": 0, "sender": "bot", "timestamp": None, "text": "buy", "flags": {"urgency": True, "emotion_count": 1}},
+        {"index": 1, "sender": "bot", "timestamp": None, "text": "please", "flags": {"guilt": True}},
+    ]
+    judge = {
+        "flagged": [
+            {"index": 0, "text": "buy", "flags": {"urgency": True}},
+            {"index": 1, "text": "please", "flags": {"guilt": True}},
+        ]
+    }
+    heur, llm = da.compute_flag_counts(features, judge)
+    assert heur["urgency"] == 1 and heur["guilt"] == 1
+    assert llm["urgency"] == 1 and llm["guilt"] == 1
+    fig = da.build_flag_comparison_figure(features, judge, "#000", "white")
+    assert fig is not None


### PR DESCRIPTION
## Summary
- compute per-flag counts for heuristic analysis and LLM judge results
- render comparison bar graph in dashboard
- test flag counting and figure creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a74abd368832eac81950d6cfbec3b