### PR TITLE
Add logging utilities with rotating files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dashboard.html
 test_results.json
 
 old_dashboard.py
+logs/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ CLAUDE_API_KEY="sk-..."
 
 Make sure to add `.env` to `.gitignore` so you never commit your secrets.
 
+## Logging
+
+Application modules use Python's ``logging`` package. Calling ``setup_logging``
+creates a ``logs/`` directory and writes rotating log files under
+``logs/framework.log``. Console output is also enabled. Entry-point scripts
+invoke this setup automatically.
+
 ## Test Dashboard
 
 Run `python scripts/test_dashboard.py` to execute the test suite and generate `dashboard.html`. The HTML file lists each test and its result so you can quickly review the status.

--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -3,6 +3,8 @@ import io
 import json
 from datetime import datetime
 from typing import Dict, Any, List
+import logging
+from logging_utils import setup_logging
 
 from insight_helpers import (
     compute_manipulation_ratio,
@@ -30,6 +32,9 @@ except Exception:  # pragma: no cover - make optional for tests
     dcc = html = Input = Output = State = _Dummy()
     go = _Dummy()
     dbc = _Dummy()
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 
 # pick one of the Bootswatch themes below:
@@ -137,6 +142,7 @@ def build_flag_comparison_figure(
 
 
 def parse_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
+    logger.debug("Parsing uploaded file %s", filename)
     content_type, content_string = contents.split(',')
     decoded = base64.b64decode(content_string)
     name = filename.lower()
@@ -181,6 +187,7 @@ def parse_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
 
 
 def analyze_conversation(conv: Dict[str, Any]) -> Dict[str, Any]:
+    logger.info("Analyzing conversation %s", conv.get('conversation_id'))
     features = static_feature_extractor.extract_conversation_features(conv)
     trust_score = scorer.score_trust(features)
     risk = scorer.compute_risk_score(features)
@@ -197,6 +204,7 @@ def analyze_conversation(conv: Dict[str, Any]) -> Dict[str, Any]:
     most_manipulative = compute_most_manipulative_message(features)
     dominance_metrics = compute_dominance_metrics(features)
 
+    logger.info("Analysis produced risk %s", risk)
     return {
         'features': features,
         'risk': risk,
@@ -539,6 +547,7 @@ def update_output(contents, view_mode, download_clicks, judge_clicks, provider, 
     text_color = "black" if light_on else "white"
     log_entries = list(debug_log or [])
     def log(msg):
+        logger.info(msg)
         log_entries.append(f"[{datetime.utcnow().isoformat()}] {msg}")
     if contents is None:
         empty_fig = go.Figure(layout=go.Layout(paper_bgcolor=bg, plot_bgcolor=bg))
@@ -566,6 +575,7 @@ def update_output(contents, view_mode, download_clicks, judge_clicks, provider, 
     conv = parse_uploaded_file(contents, filename)
     results = analyze_conversation(conv)
     log("analysis complete")
+    logger.debug("Finished analysis of uploaded file")
 
     ts = datetime.utcnow().isoformat()
     file_info = f"{filename} ({ts})"
@@ -948,10 +958,13 @@ def update_output(contents, view_mode, download_clicks, judge_clicks, provider, 
     if judge_clicks:
         try:
             log(f"requesting {provider or 'auto'} ...")
+            logger.debug("Sending judge request")
             judge_results = judge_conversation_llm(conv, provider=provider or "auto")
             log("received response")
+            logger.debug("Judge response parsed")
         except Exception as exc:  # pragma: no cover - network errors etc
             log(f"error: {exc}")
+            logger.warning("Judge request failed: %s", exc)
             judge_div = dbc.Alert(str(exc), color="warning", className="mt-2")
         else:
             if judge_results and isinstance(judge_results, dict):
@@ -965,6 +978,7 @@ def update_output(contents, view_mode, download_clicks, judge_clicks, provider, 
                     rows.append(html.Tr(row))
                 judge_div = html.Table(rows, className="table table-sm table-dark")
                 log("processed results")
+                logger.debug("Merged judge results for plotting")
             else:
                 judge_div = html.Div("No manipulative bot messages detected.", className="text-muted")
 
@@ -1042,4 +1056,5 @@ def display_debug(logs):
 
 
 if __name__ == "__main__":
+    setup_logging()
     app.run(debug=False)

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,30 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+
+def setup_logging(log_file: str = "logs/framework.log") -> None:
+    """Configure root logger with a rotating file handler.
+
+    The log folder is created automatically. Subsequent calls are no-ops
+    so ``setup_logging`` can be invoked safely from multiple modules.
+    """
+    path = Path(log_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    logger = logging.getLogger()
+    if any(isinstance(h, RotatingFileHandler) for h in logger.handlers):
+        return
+
+    logger.setLevel(logging.INFO)
+
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    )
+    file_handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    stream = logging.StreamHandler()
+    stream.setFormatter(formatter)
+    logger.addHandler(stream)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,15 @@
 from scripts.input_parser import parse_json_chat, parse_txt_chat, standardize_format
+import logging
+from logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+
+setup_logging()
 
 raw1 = parse_json_chat("data/example.json")
 std1 = standardize_format(raw1)
-print("Standardized format json", std1)
+logger.info("Standardized format json %s", std1)
 
 raw2 = parse_txt_chat("data/example.txt")
 std2 = standardize_format(raw2)
-print("Standardized format txt",std2)
+logger.info("Standardized format txt %s", std2)

--- a/scripts/judge_conversation.py
+++ b/scripts/judge_conversation.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 import os
+import logging
+from logging_utils import setup_logging
 
 from api.api_calls import (
     call_chatgpt,
@@ -11,6 +13,9 @@ from api.api_calls import (
     call_mistral,
     call_gemini,
 )
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 
 _PROVIDER_MAP = {
@@ -48,6 +53,8 @@ def _judge_single(conversation: Dict[str, Any], provider: str) -> Dict[str, Any]
     if len(messages) >= 500:
         raise ValueError("Conversation must contain fewer than 500 messages")
 
+    logger.info("Judging conversation with %s", provider)
+
     prov_key = _PROVIDER_MAP.get(provider.lower())
     if prov_key is None:
         raise ValueError(f"Unknown provider: {provider}")
@@ -69,8 +76,10 @@ def _judge_single(conversation: Dict[str, Any], provider: str) -> Dict[str, Any]
 
     try:
         content = resp["choices"][0]["message"]["content"]
+        logger.debug("Received response from %s", provider)
         return json.loads(content)
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to parse response from %s: %s", provider, exc)
         return []
 
 
@@ -93,11 +102,14 @@ def judge_conversation_llm(conversation: Dict[str, Any], provider: str = "auto")
         for prov in ["openai", "gemini", "claude", "mistral"]:
             env_var = _API_KEY_ENV.get(prov, "")
             if env_var and os.getenv(env_var):
+                logger.info("Calling provider %s", prov)
                 try:
                     results[prov] = _judge_single(conversation, prov)
                 except Exception:
                     # skip failing providers
+                    logger.warning("Provider %s failed", prov)
                     continue
         return results
 
+    logger.info("Calling single provider %s", provider)
     return _judge_single(conversation, provider)

--- a/scripts/static_feature_extractor.py
+++ b/scripts/static_feature_extractor.py
@@ -2,6 +2,9 @@
 
 import re
 from typing import List, Dict, Any
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 # -------------------------------------------------------------------------------------------------
@@ -151,6 +154,7 @@ def extract_message_features(text: str) -> Dict[str, Any]:
     fear/threats, gaslighting and deception cues.  The return dictionary
     contains a boolean flag for each tactic and an ``emotion_count``.
     """
+    logger.debug("Extracting features from text: %s", text[:30])
     flags = {
         "urgency": False,
         "guilt": False,
@@ -199,6 +203,9 @@ def extract_conversation_features(
 
     This provides a feature set per message for downstream scoring.
     """
+    logger.info(
+        "Extracting features for conversation %s", conversation.get("conversation_id")
+    )
     results = []
     messages = conversation.get("messages", [])
 
@@ -214,4 +221,5 @@ def extract_conversation_features(
             "flags": flags
         })
 
+    logger.info("Extracted features for %d messages", len(results))
     return results

--- a/scripts/test_dashboard.py
+++ b/scripts/test_dashboard.py
@@ -1,9 +1,17 @@
 """Generate a simple HTML dashboard summarizing pytest results."""
 
+import os
+import sys
 import json
 import subprocess
 from html import escape
 from pathlib import Path
+import logging
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def run_tests(json_path: str = "test_results.json") -> None:
@@ -36,9 +44,10 @@ def build_dashboard(json_path: str = "test_results.json", html_path: str = "dash
 
 
 def main() -> None:
+    setup_logging()
     run_tests()
     build_dashboard()
-    print("Dashboard written to dashboard.html")
+    logger.info("Dashboard written to dashboard.html")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `logging_utils.setup_logging` with rotating file handler
- ignore `logs/` output directory
- switch `dashboard_app` to use the logger and record debug info
- instrument parsing and feature extraction code with logging
- update CLI scripts and demos to initialise logging
- mention logging behaviour in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a87dbc098832e95ff1fcc8acbc852