### PR TITLE
Fix ChatCompletion handling

### DIFF
--- a/api/chatgpt_api.py
+++ b/api/chatgpt_api.py
@@ -90,6 +90,15 @@ def call_chatgpt(
                     top_p=top_p,
                     n=n,
                 )
+
+            # Newer OpenAI clients return a ChatCompletion object. Convert to a
+            # plain dictionary so callers can use a consistent interface.
+            if not isinstance(response, dict):
+                if hasattr(response, "model_dump"):
+                    response = response.model_dump()
+                elif hasattr(response, "to_dict"):
+                    response = response.to_dict()
+
             return response
         except (RateLimitError, APIConnectionError) as e:
             last_err = e

--- a/manipulation_detector.py
+++ b/manipulation_detector.py
@@ -12,7 +12,15 @@ def detect_manipulation(api_response: Dict[str, Any]) -> Dict[str, Any]:
     an empty dictionary.
     """
     try:
-        content = api_response["choices"][0]["message"]["content"]
+        if isinstance(api_response, dict):
+            content = api_response["choices"][0]["message"]["content"]
+        elif hasattr(api_response, "model_dump"):
+            data = api_response.model_dump()
+            content = data["choices"][0]["message"]["content"]
+        elif hasattr(api_response, "choices"):
+            content = api_response.choices[0].message.content
+        else:
+            return {}
     except Exception:
         return {}
 

--- a/scripts/judge_conversation.py
+++ b/scripts/judge_conversation.py
@@ -79,7 +79,16 @@ def _judge_single(conversation: Dict[str, Any], provider: str) -> Dict[str, Any]
         raise ValueError(f"Unsupported provider: {provider}")
 
     try:
-        content = resp["choices"][0]["message"]["content"]
+        if isinstance(resp, dict):
+            content = resp["choices"][0]["message"]["content"]
+        elif hasattr(resp, "model_dump"):
+            data = resp.model_dump()
+            content = data["choices"][0]["message"]["content"]
+        elif hasattr(resp, "choices"):
+            content = resp.choices[0].message.content
+        else:
+            raise TypeError("Unsupported response type")
+
         logger.debug("Received response from %s", provider)
         llm_logger.info("%s: %s", provider, content)
 

--- a/tests/test_chatgpt_api.py
+++ b/tests/test_chatgpt_api.py
@@ -1,0 +1,40 @@
+import importlib, sys
+
+import pytest
+
+import api.chatgpt_api as cga
+
+
+def test_call_chatgpt_converts_object(monkeypatch):
+    class DummyResp:
+        def __init__(self, content):
+            self.choices = [type('C', (), {'message': type('M', (), {'content': content})()})()]
+
+        def model_dump(self):
+            return {"choices": [{"message": {"content": self.choices[0].message.content}}]}
+
+    class DummyClient:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    return DummyResp('{"ok": true}')
+
+    class FakeOpenAI:
+        __version__ = "1.2.0"
+        OpenAI = DummyClient
+        RateLimitError = Exception
+        APIConnectionError = Exception
+        OpenAIError = Exception
+
+    monkeypatch.setitem(sys.modules, "openai", FakeOpenAI)
+    importlib.reload(cga)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    result = cga.call_chatgpt("hi")
+    assert isinstance(result, dict)
+    assert result["choices"][0]["message"]["content"] == '{"ok": true}'

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -17,6 +17,26 @@ def test_detect_manipulation():
     assert md.detect_manipulation({}) == {}
 
 
+def test_detect_manipulation_object():
+    class Msg:
+        def __init__(self, content):
+            self.content = content
+
+    class Choice:
+        def __init__(self, content):
+            self.message = Msg(content)
+
+    class DummyResp:
+        def __init__(self, content):
+            self.choices = [Choice(content)]
+
+        def model_dump(self):
+            return {"choices": [{"message": {"content": self.choices[0].message.content}}]}
+
+    obj = DummyResp('{"key": "value"}')
+    assert md.detect_manipulation(obj) == {"key": "value"}
+
+
 def test_classify_manipulation_type():
     assert md.classify_manipulation_type({"urgency": True}) == "pressure"
     assert md.classify_manipulation_type({"guilt": True}) == "guilt"


### PR DESCRIPTION
## Summary
- convert ChatGPT responses to dicts in `call_chatgpt`
- support parsing ChatCompletion objects in `judge_conversation` and `detect_manipulation`
- add tests for ChatCompletion handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd30543f4832ea6f14cd0f0b1625d