### PR TITLE
Fix ChatCompletion handling

### DIFF
--- a/api/chatgpt_api.py
+++ b/api/chatgpt_api.py
@@ -90,6 +90,15 @@ def call_chatgpt(
                     top_p=top_p,
                     n=n,
                 )
+
+            # Newer OpenAI clients return a ChatCompletion object. Convert to a
+            # plain dictionary so callers can use a consistent interface.
+            if not isinstance(response, dict):
+                if hasattr(response, "model_dump"):
+                    response = response.model_dump()
+                elif hasattr(response, "to_dict"):
+                    response = response.to_dict()
+
             return response
         except (RateLimitError, APIConnectionError) as e:
             last_err = e

--- a/manipulation_detector.py
+++ b/manipulation_detector.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Any, Dict
+from helpers import extract_json_block
 
 
 def detect_manipulation(api_response: Dict[str, Any]) -> Dict[str, Any]:
@@ -12,12 +13,24 @@ def detect_manipulation(api_response: Dict[str, Any]) -> Dict[str, Any]:
     an empty dictionary.
     """
     try:
-        content = api_response["choices"][0]["message"]["content"]
+        if isinstance(api_response, dict):
+            content = api_response["choices"][0]["message"]["content"]
+        elif hasattr(api_response, "model_dump"):
+            data = api_response.model_dump()
+            content = data["choices"][0]["message"]["content"]
+        elif hasattr(api_response, "choices"):
+            content = api_response.choices[0].message.content
+        else:
+            return {}
     except Exception:
         return {}
 
+    json_str = extract_json_block(content)
+    if json_str is None:
+        return {}
+
     try:
-        return json.loads(content)
+        return json.loads(json_str)
     except Exception:
         return {}
 

--- a/tests/test_chatgpt_api.py
+++ b/tests/test_chatgpt_api.py
@@ -1,0 +1,40 @@
+import importlib, sys
+
+import pytest
+
+import api.chatgpt_api as cga
+
+
+def test_call_chatgpt_converts_object(monkeypatch):
+    class DummyResp:
+        def __init__(self, content):
+            self.choices = [type('C', (), {'message': type('M', (), {'content': content})()})()]
+
+        def model_dump(self):
+            return {"choices": [{"message": {"content": self.choices[0].message.content}}]}
+
+    class DummyClient:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    return DummyResp('{"ok": true}')
+
+    class FakeOpenAI:
+        __version__ = "1.2.0"
+        OpenAI = DummyClient
+        RateLimitError = Exception
+        APIConnectionError = Exception
+        OpenAIError = Exception
+
+    monkeypatch.setitem(sys.modules, "openai", FakeOpenAI)
+    importlib.reload(cga)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    result = cga.call_chatgpt("hi")
+    assert isinstance(result, dict)
+    assert result["choices"][0]["message"]["content"] == '{"ok": true}'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,9 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import helpers
+
+
+def test_extract_json_block():
+    text = "prefix ```json\n{\"a\": 1}\n``` suffix"
+    assert helpers.extract_json_block(text) == '{"a": 1}'

--- a/tests/test_judge_conversation.py
+++ b/tests/test_judge_conversation.py
@@ -43,6 +43,17 @@ def test_judge_conversation_parse_fail(monkeypatch):
     assert judge_conversation_llm(conv, provider="openai") == []
 
 
+def test_judge_conversation_strip_fences(monkeypatch):
+    conv = {"conversation_id": "cf", "messages": [{"sender": "bot", "timestamp": None, "text": "hi"}]}
+
+    def fake_call(prompt, api_key=None, **kw):
+        content = "Sure!\n```json\n{\"flagged\": []}\n```"
+        return {"choices": [{"message": {"content": content}}]}
+
+    monkeypatch.setattr('scripts.judge_conversation.call_chatgpt', fake_call)
+    assert judge_conversation_llm(conv, provider="openai") == {"flagged": []}
+
+
 def test_judge_conversation_llm_old_api(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
@@ -202,3 +213,29 @@ def test_merge_judge_results_from_auto(monkeypatch):
     merged = merge_judge_results(result)
     texts = [f["text"] for f in merged["flagged"]]
     assert set(texts) == {"gemini", "claude", "mistral"}
+
+
+def test_judge_conversation_with_object_response(monkeypatch):
+    class Msg:
+        def __init__(self, content):
+            self.content = content
+
+    class Choice:
+        def __init__(self, content):
+            self.message = Msg(content)
+
+    class DummyResp:
+        def __init__(self, content):
+            self.choices = [Choice(content)]
+
+        def model_dump(self):
+            return {"choices": [{"message": {"content": self.choices[0].message.content}}]}
+
+    def fake_call(prompt, api_key=None, **kw):
+        return DummyResp('{"flagged": []}')
+
+    monkeypatch.setattr('scripts.judge_conversation.call_chatgpt', fake_call)
+
+    conv = {"conversation_id": "obj", "messages": [{"sender": "bot", "timestamp": None, "text": "hello"}]}
+    result = judge_conversation_llm(conv, provider="openai")
+    assert result == {"flagged": []}


### PR DESCRIPTION
## Summary
- convert ChatGPT responses to dicts in `call_chatgpt`
- support parsing ChatCompletion objects in `judge_conversation` and `detect_manipulation`
- add tests for ChatCompletion handling
- add helper to extract JSON from LLM output and improve parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd30543f4832ea6f14cd0f0b1625d