### PR TITLE
Fix JSON parsing for multi-response outputs

### DIFF
--- a/api/chatgpt_api.py
+++ b/api/chatgpt_api.py
@@ -90,6 +90,15 @@ def call_chatgpt(
                     top_p=top_p,
                     n=n,
                 )
+
+            # Newer OpenAI clients return a ChatCompletion object. Convert to a
+            # plain dictionary so callers can use a consistent interface.
+            if not isinstance(response, dict):
+                if hasattr(response, "model_dump"):
+                    response = response.model_dump()
+                elif hasattr(response, "to_dict"):
+                    response = response.to_dict()
+
             return response
         except (RateLimitError, APIConnectionError) as e:
             last_err = e

--- a/helpers.py
+++ b/helpers.py
@@ -38,3 +38,45 @@ def safe_load_json(data: str) -> Optional[Any]:
 def log_error(message: str) -> None:
     """Log an error message using the logging module."""
     logging.error(message)
+
+
+def extract_json_block(text: str) -> Optional[str]:
+    """Return the first valid JSON object found in ``text``.
+
+    The function strips common code fences (``` or ```json) and then
+    attempts to locate a JSON object within the remaining string. If a
+    valid JSON block is found, the JSON substring is returned. Otherwise
+    ``None`` is returned.
+    """
+
+    if not isinstance(text, str):
+        return None
+
+    cleaned = text.strip()
+
+    # Remove ``` fences which LLMs often include
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        if cleaned.lower().startswith("json"):
+            cleaned = cleaned.partition("\n")[2]
+        if cleaned.endswith("```"):
+            cleaned = cleaned.rsplit("```", 1)[0]
+
+    # Try direct parse first
+    try:
+        json.loads(cleaned)
+        return cleaned
+    except Exception:
+        pass
+
+    # Scan for the first valid JSON object in the text
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(cleaned):
+        if ch in "{[":
+            try:
+                obj, end = decoder.raw_decode(cleaned[i:])
+                return cleaned[i : i + end]
+            except Exception:
+                continue
+
+    return None

--- a/manipulation_detector.py
+++ b/manipulation_detector.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Any, Dict
+from helpers import extract_json_block
 
 
 def detect_manipulation(api_response: Dict[str, Any]) -> Dict[str, Any]:
@@ -12,12 +13,24 @@ def detect_manipulation(api_response: Dict[str, Any]) -> Dict[str, Any]:
     an empty dictionary.
     """
     try:
-        content = api_response["choices"][0]["message"]["content"]
+        if isinstance(api_response, dict):
+            content = api_response["choices"][0]["message"]["content"]
+        elif hasattr(api_response, "model_dump"):
+            data = api_response.model_dump()
+            content = data["choices"][0]["message"]["content"]
+        elif hasattr(api_response, "choices"):
+            content = api_response.choices[0].message.content
+        else:
+            return {}
     except Exception:
         return {}
 
+    json_str = extract_json_block(content)
+    if json_str is None:
+        return {}
+
     try:
-        return json.loads(content)
+        return json.loads(json_str)
     except Exception:
         return {}
 

--- a/tests/test_chatgpt_api.py
+++ b/tests/test_chatgpt_api.py
@@ -1,0 +1,40 @@
+import importlib, sys
+
+import pytest
+
+import api.chatgpt_api as cga
+
+
+def test_call_chatgpt_converts_object(monkeypatch):
+    class DummyResp:
+        def __init__(self, content):
+            self.choices = [type('C', (), {'message': type('M', (), {'content': content})()})()]
+
+        def model_dump(self):
+            return {"choices": [{"message": {"content": self.choices[0].message.content}}]}
+
+    class DummyClient:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    return DummyResp('{"ok": true}')
+
+    class FakeOpenAI:
+        __version__ = "1.2.0"
+        OpenAI = DummyClient
+        RateLimitError = Exception
+        APIConnectionError = Exception
+        OpenAIError = Exception
+
+    monkeypatch.setitem(sys.modules, "openai", FakeOpenAI)
+    importlib.reload(cga)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    result = cga.call_chatgpt("hi")
+    assert isinstance(result, dict)
+    assert result["choices"][0]["message"]["content"] == '{"ok": true}'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,14 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import helpers
+
+
+def test_extract_json_block():
+    text = "prefix ```json\n{\"a\": 1}\n``` suffix"
+    assert helpers.extract_json_block(text) == '{"a": 1}'
+
+
+def test_extract_json_block_multiple_jsons():
+    text = 'first {"a": 1} second {"b": 2}'
+    assert helpers.extract_json_block(text) == '{"a": 1}'

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -17,6 +17,36 @@ def test_detect_manipulation():
     assert md.detect_manipulation({}) == {}
 
 
+def test_detect_manipulation_object():
+    class Msg:
+        def __init__(self, content):
+            self.content = content
+
+    class Choice:
+        def __init__(self, content):
+            self.message = Msg(content)
+
+    class DummyResp:
+        def __init__(self, content):
+            self.choices = [Choice(content)]
+
+        def model_dump(self):
+            return {"choices": [{"message": {"content": self.choices[0].message.content}}]}
+
+    obj = DummyResp('{"key": "value"}')
+    assert md.detect_manipulation(obj) == {"key": "value"}
+
+
+def test_detect_manipulation_with_noise():
+    resp = {"choices": [{"message": {"content": 'Here\nit is:\n```json\n{"key": "value"}\n```'}}]}
+    assert md.detect_manipulation(resp) == {"key": "value"}
+
+
+def test_detect_manipulation_multiple_json():
+    resp = {"choices": [{"message": {"content": '{"key": 1}\n{"other": 2}'}}]}
+    assert md.detect_manipulation(resp) == {"key": 1}
+
+
 def test_classify_manipulation_type():
     assert md.classify_manipulation_type({"urgency": True}) == "pressure"
     assert md.classify_manipulation_type({"guilt": True}) == "guilt"


### PR DESCRIPTION
## Summary
- expand `extract_json_block` to scan for the first valid JSON object, handling multiple JSON blocks
- add tests for multiple JSON responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd30543f4832ea6f14cd0f0b1625d