### PR TITLE
Add unsupported file type handling

### DIFF
--- a/tests/test_update_output.py
+++ b/tests/test_update_output.py
@@ -216,6 +216,14 @@ def test_parse_uploaded_file_csv():
     assert len(result["messages"]) == 2
     assert result["messages"][1]["text"] == "hello"
 
+def test_parse_uploaded_file_unknown():
+    binary = b"\x00\x01"
+    enc = base64.b64encode(binary).decode()
+    contents = f"data:application/octet-stream;base64,{enc}"
+    result = da.parse_uploaded_file(contents, "data.bin")
+    assert result["conversation_id"] == "data"
+    assert result.get("error") == "Unsupported file type"
+
 def test_update_output_with_judge(monkeypatch):
     if hasattr(da, "_Dummy") and isinstance(da.dash, da._Dummy):
         pytest.skip("Dash not installed")


### PR DESCRIPTION
## Summary
- log a warning for unknown upload types in `parse_uploaded_file`
- attach an `error` field to the returned conversation when the file is unsupported
- test uploading a `.bin` file to ensure the error field is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf4575fd4832ea8f9a4be0f99f5b0