### PR TITLE
Add judge-store to cache LLM results

### DIFF
--- a/tests/test_update_output.py
+++ b/tests/test_update_output.py
@@ -230,10 +230,17 @@ def test_update_output_with_judge(monkeypatch):
         "reinforcement_loops",
         *[f for f, _ in da.NEW_FLAGS]
     ]
-    out = da.update_output("data:,", "raw", 0, 1, "openai", selected, "x.json", True, [])
+    out = da.update_output("data:,", "raw", 0, 1, "openai", selected, "x.json", True, [], None)
     summary = out[20]
     timeline = out[17]
     comparison = out[18]
+    store = out[26]
     assert "Total flagged: 9" in summary
     assert len(timeline.data) == 2
     assert len(comparison.data) == 2
+
+    # second call without button click should reuse stored results
+    out2 = da.update_output("data:,", "raw", 0, 0, "openai", selected, "x.json", True, [], store)
+    assert "Total flagged: 9" in out2[20]
+    assert len(out2[17].data) == 2
+    assert len(out2[18].data) == 2


### PR DESCRIPTION
## Summary
- add `judge-store` to layout to keep LLM judge results
- update callback to read/write the new store
- reuse stored results when judge button is not clicked
- extend tests to simulate persisted results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cfca18e9c832e8a4ae361d9a22463