### PR TITLE
Handle empty LLM judge results

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -217,9 +217,11 @@ def analyze_conversation(conv: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def summarize_judge_results(judge_results: Dict[str, Any]) -> str:
-    if not isinstance(judge_results, dict):
-        return ""
-    flagged = judge_results.get("flagged", [])
+    """Return a short summary of LLM judge results."""
+    if not isinstance(judge_results, dict) or not judge_results:
+        flagged = []
+    else:
+        flagged = judge_results.get("flagged") or []
     counts = {f: 0 for f in ALL_FLAG_NAMES}
     for item in flagged:
         for f in ALL_FLAG_NAMES:
@@ -1061,11 +1063,11 @@ def update_output(
             else:
                 merged_for_plots = merge_judge_results(judge_results)
                 if not merged_for_plots.get("flagged"):
-                    msg = "LLM judge returned no results – check API keys."
-                    log(msg)
-                    judge_div = dbc.Alert(msg, color="warning", className="mt-2")
-                    summary_text = msg
-                    judge_results = None
+                    judge_div = html.Div(
+                        "No manipulative bot messages detected.",
+                        className="text-muted",
+                    )
+                    summary_text = summarize_judge_results(merged_for_plots)
                 else:
                     header = [html.Th("Index"), html.Th("Text")] + [html.Th(f.replace('_', ' ').title()) for f in ALL_FLAG_NAMES]
                     rows = [html.Tr(header)]

--- a/tests/test_llm_summary.py
+++ b/tests/test_llm_summary.py
@@ -16,6 +16,11 @@ def test_summarize_judge_results():
     assert "Flattery: 1" in text
 
 
+def test_summarize_judge_results_empty():
+    assert da.summarize_judge_results({}) == "Total flagged: 0"
+    assert da.summarize_judge_results(None) == "Total flagged: 0"
+
+
 def test_judge_timeline_trace():
     features = [
         {"index": 0, "sender": "bot", "timestamp": None, "text": "buy", "flags": {"urgency": True}},

--- a/tests/test_update_output.py
+++ b/tests/test_update_output.py
@@ -320,7 +320,7 @@ def test_update_output_judge_no_results(monkeypatch):
     ]
 
     out = da.update_output("data:,", "raw", 0, 1, "openai", selected, "x.json", True, [], None)
-    assert "LLM judge returned no results" in out[20]
+    assert "Total flagged: 0" in out[20]
     judge_div = out[21]
     text = getattr(judge_div, "children", judge_div)
-    assert "check api keys" in str(text).lower()
+    assert "no manipulative" in str(text).lower()


### PR DESCRIPTION
## Summary
- make `summarize_judge_results` handle empty/None input
- show `Total flagged: 0` when LLM judge returns no flags
- test empty summary case
- adjust no-result regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5cc456a0832ea9954ef376147258