### PR TITLE
Handle missing API keys for auto judge

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -1049,6 +1049,11 @@ def update_output(
             judge_results = judge_conversation_llm(conv, provider=provider or "auto")
             log("received response")
             logger.debug("Judge response parsed")
+        except RuntimeError as exc:
+            log(f"error: {exc}")
+            logger.warning("Judge request failed: %s", exc)
+            judge_div = dbc.Alert(str(exc), color="warning", className="mt-2")
+            judge_results = None
         except Exception as exc:  # pragma: no cover - network errors etc
             log(f"error: {exc}")
             logger.warning("Judge request failed: %s", exc)

--- a/scripts/judge_conversation.py
+++ b/scripts/judge_conversation.py
@@ -117,6 +117,10 @@ def judge_conversation_llm(conversation: Dict[str, Any], provider: str = "auto")
         raise ValueError("Conversation must contain fewer than 500 messages")
 
     if provider.lower() == "auto":
+        if not any(os.getenv(v) for v in _API_KEY_ENV.values()):
+            raise RuntimeError(
+                "No API keys found for automatic provider selection."
+            )
         results: Dict[str, Any] = {}
         for prov in ["openai", "gemini", "claude", "mistral"]:
             env_var = _API_KEY_ENV.get(prov, "")

--- a/tests/test_judge_conversation.py
+++ b/tests/test_judge_conversation.py
@@ -250,3 +250,13 @@ def test_judge_conversation_with_object_response(monkeypatch):
     conv = {"conversation_id": "obj", "messages": [{"sender": "bot", "timestamp": None, "text": "hello"}]}
     result = judge_conversation_llm(conv, provider="openai")
     assert result == {"flagged": []}
+
+
+def test_judge_conversation_auto_no_keys(monkeypatch):
+    conv = {"conversation_id": "n", "messages": [{"sender": "bot", "timestamp": None, "text": "x"}]}
+
+    for env in ["OPENAI_API_KEY", "GEMINI_API_KEY", "CLAUDE_API_KEY", "MISTRAL_API_KEY"]:
+        monkeypatch.delenv(env, raising=False)
+
+    with pytest.raises(RuntimeError):
+        judge_conversation_llm(conv, provider="auto")


### PR DESCRIPTION
## Summary
- raise an error when no API keys are available for automatic provider selection
- surface this `RuntimeError` through `update_output`
- test the behaviour in `judge_conversation_llm`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5e56a210832e89339d747b58a7af