### PR TITLE
Improve judge feedback and graphs

### DIFF
--- a/tests/test_judge_conversation.py
+++ b/tests/test_judge_conversation.py
@@ -180,6 +180,16 @@ def test_judge_conversation_auto_partial(monkeypatch):
     result = judge_conversation_llm(conv, provider="auto")
     assert list(result.keys()) == ["openai"]
 
+
+def test_judge_conversation_auto_no_keys(monkeypatch):
+    conv = {"conversation_id": "none", "messages": [{"sender": "bot", "timestamp": None, "text": "x"}]}
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        judge_conversation_llm(conv, provider="auto")
+
 def test_merge_judge_results_passthrough():
     data = {"flagged": [{"index": 0}]}
     assert merge_judge_results(data) == data

--- a/tests/test_update_output.py
+++ b/tests/test_update_output.py
@@ -320,7 +320,7 @@ def test_update_output_judge_no_results(monkeypatch):
     ]
 
     out = da.update_output("data:,", "raw", 0, 1, "openai", selected, "x.json", True, [], None)
-    assert "Total flagged: 0" in out[20]
+    assert "no results" in out[20].lower()
     judge_div = out[21]
     text = getattr(judge_div, "children", judge_div)
-    assert "no manipulative" in str(text).lower()
+    assert "no results" in str(text).lower()


### PR DESCRIPTION
## Summary
- alert users when LLM judge can't run
- raise `RuntimeError` if no API keys available
- rework timeline/pattern breakdown graphs
- update tests for new behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4ef897c4832ea6fd539d80d51f03