### PR TITLE
Improve JSON parse logging

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 from datetime import datetime
 from typing import Any, Optional
 
@@ -66,8 +68,8 @@ def extract_json_block(text: str) -> Optional[str]:
     try:
         json.loads(cleaned)
         return cleaned
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("JSON parse failed: %s", exc)
 
     # Scan for the first valid JSON object in the text
     decoder = json.JSONDecoder()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import logging
 import helpers
 
 
@@ -11,4 +12,12 @@ def test_extract_json_block():
 def test_extract_json_block_multiple_jsons():
     text = 'first {"a": 1} second {"b": 2}'
     assert helpers.extract_json_block(text) == '{"a": 1}'
+
+
+def test_extract_json_block_logs_malformed(caplog):
+    text = 'not json'
+    with caplog.at_level(logging.DEBUG):
+        result = helpers.extract_json_block(text)
+    assert result is None
+    assert any('JSON parse failed' in rec.message for rec in caplog.records)
 


### PR DESCRIPTION
## Summary
- add module logger in `helpers`
- log JSON parse errors in `extract_json_block`
- test that malformed JSON triggers debug logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7c3d005c832eb7ae6d45f687c24a