### PR TITLE
Improve guidance when API keys missing

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -1161,12 +1161,13 @@ def update_output(
             log("received response")
             logger.debug("Judge response parsed")
         except RuntimeError as exc:
-            log(f"error: {exc}")
-            logger.warning("Judge request failed: %s", exc)
-            judge_div = dbc.Alert(str(exc), color="warning", className="mt-2")
+            msg = str(exc)
+            log(f"error: {msg}")
+            logger.warning("Judge request failed: %s", msg)
+            judge_div = dbc.Alert(msg, color="warning", className="mt-2")
             judge_results = None
 
-            summary_text = str(exc)
+            summary_text = msg
         except Exception as exc:  # pragma: no cover - network errors etc
             log(f"error: {exc}")
             logger.warning("Judge request failed: %s", exc)

--- a/scripts/judge_conversation.py
+++ b/scripts/judge_conversation.py
@@ -123,7 +123,9 @@ def judge_conversation_llm(conversation: Dict[str, Any], provider: str = "auto")
             if _API_KEY_ENV.get(prov) and os.getenv(_API_KEY_ENV[prov])
         ]
         if not available:
-            raise RuntimeError("No LLM API keys available")
+            raise RuntimeError(
+                "No LLM API keys available. Set OPENAI_API_KEY or other provider keys."
+            )
         results: Dict[str, Any] = {}
         for prov in available:
             logger.info("Calling provider %s", prov)

--- a/tests/test_judge_conversation.py
+++ b/tests/test_judge_conversation.py
@@ -187,8 +187,9 @@ def test_judge_conversation_auto_no_keys(monkeypatch):
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as excinfo:
         judge_conversation_llm(conv, provider="auto")
+    assert "OPENAI_API_KEY" in str(excinfo.value)
 
 def test_merge_judge_results_passthrough():
     data = {"flagged": [{"index": 0}]}
@@ -268,5 +269,6 @@ def test_judge_conversation_auto_no_keys(monkeypatch):
     for env in ["OPENAI_API_KEY", "GEMINI_API_KEY", "CLAUDE_API_KEY", "MISTRAL_API_KEY"]:
         monkeypatch.delenv(env, raising=False)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as excinfo:
         judge_conversation_llm(conv, provider="auto")
+    assert "OPENAI_API_KEY" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- clarify missing key guidance in `judge_conversation_llm`
- surface the same message in dashboard alerts
- check that the guidance appears in `test_judge_conversation`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9235fa5c832e92dad289576a0782