### PR TITLE
Add px dummy fallback for graph colors

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -35,6 +35,7 @@ except Exception:  # pragma: no cover - make optional for tests
     dcc = html = Input = Output = State = _Dummy()
     go = _Dummy()
     dbc = _Dummy()
+    px = _Dummy()
 
 setup_logging()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- define `px` as a `_Dummy` in `dashboard_app` when plotly isn't installed
- ensures calls to `px.colors` won't fail during optional usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa2c5de78832ea6f0de3dbb788174