### PR TITLE
Add test for dashboard callback handling

### DIFF
--- a/tests/test_dashboard_llm_output.py
+++ b/tests/test_dashboard_llm_output.py
@@ -39,3 +39,65 @@ def test_dashboard_llm_output(monkeypatch):
     assert "features" in analysis and "risk" in analysis
     heur, llm = da.compute_flag_counts(analysis["features"], merged)
     assert llm["urgency"] == 1
+
+
+def test_update_output_callback(monkeypatch):
+    conv = {
+        "conversation_id": "cb",
+        "messages": [{"sender": "bot", "timestamp": None, "text": "Buy now!"}],
+    }
+    analysis = {
+        "features": [
+            {"index": 0, "sender": "bot", "timestamp": None, "text": "Buy now!", "flags": {}}
+        ],
+        "risk": 0,
+        "summary": {
+            "dark_patterns": 0,
+            "emotional_framing": 0,
+            "parasocial_pressure": 0,
+            "reinforcement_loops": 0,
+            "guilt": 0,
+            "social_proof": 0,
+            "authority": 0,
+            "reciprocity": 0,
+            "consistency": 0,
+            "dependency": 0,
+            "fear": 0,
+            "gaslighting": 0,
+            "deception": 0,
+        },
+        "manipulation_ratio": 0,
+        "manipulation_timeline": [0],
+        "most_manipulative": {},
+        "dominance_metrics": {
+            "avg_user_msg_length": 0.0,
+            "avg_bot_msg_length": 2.0,
+            "user_msg_count": 0,
+            "bot_msg_count": 1,
+            "user_word_share": 0.0,
+            "bot_word_share": 1.0,
+        },
+    }
+    fake_results = {
+        "flagged": [
+            {"index": 0, "text": "Buy now!", "flags": {"urgency": True}}
+        ]
+    }
+    monkeypatch.setattr(da, "parse_uploaded_file", lambda c, f: conv)
+    monkeypatch.setattr(da, "analyze_conversation", lambda c: analysis)
+    monkeypatch.setattr(da, "judge_conversation_llm", lambda c, provider="auto": fake_results)
+
+    outputs = da.update_output(
+        "data:text/plain;base64,Zm9v",  # dummy content
+        "plain",
+        0,
+        1,
+        "openai",
+        [],
+        "conv.json",
+        False,
+        [],
+        None,
+    )
+    assert outputs[23] == fake_results
+    assert any("processed results" in entry for entry in outputs[22])


### PR DESCRIPTION
## Summary
- test dashboard update_output callback to ensure judge results are stored
- verify debug logs mention processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f3e2db60832e868c2278e7781f9d