### PR TITLE
Consolidate judge flags table

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -981,13 +981,16 @@ def update_output(
                     summary_text = "LLM judge returned no results \u2013 check API keys."
                     judge_div = dbc.Alert(summary_text, color="warning", className="mt-2")
                 else:
-                    header = [html.Th("Index"), html.Th("Text")] + [html.Th(f.replace('_', ' ').title()) for f in ALL_FLAG_NAMES]
+                    header = [html.Th("Index"), html.Th("Text"), html.Th("Flags")]
                     rows = [html.Tr(header)]
                     for item in merged_for_plots.get("flagged", []):
-                        row = [html.Td(item.get("index")), html.Td(item.get("text"))]
                         flags = item.get("flags", {})
-                        for f in ALL_FLAG_NAMES:
-                            row.append(html.Td(str(flags.get(f, False))))
+                        true_flags = [name.replace('_', ' ').title() for name, val in flags.items() if val]
+                        row = [
+                            html.Td(item.get("index")),
+                            html.Td(item.get("text")),
+                            html.Td(", ".join(true_flags)),
+                        ]
                         rows.append(html.Tr(row))
                     judge_div = html.Table(rows, className="table table-sm table-dark")
                     log("processed results")
@@ -1000,13 +1003,16 @@ def update_output(
             merged_for_plots = merge_judge_results(judge_results)
         else:
             if isinstance(judge_results, dict):
-                header = [html.Th("Index"), html.Th("Text")] + [html.Th(f.replace('_', ' ').title()) for f in ALL_FLAG_NAMES]
+                header = [html.Th("Index"), html.Th("Text"), html.Th("Flags")]
                 rows = [html.Tr(header)]
                 for item in judge_results.get("flagged", []):
-                    row = [html.Td(item.get("index")), html.Td(item.get("text"))]
                     flags = item.get("flags", {})
-                    for f in ALL_FLAG_NAMES:
-                        row.append(html.Td(str(flags.get(f, False))))
+                    true_flags = [name.replace('_', ' ').title() for name, val in flags.items() if val]
+                    row = [
+                        html.Td(item.get("index")),
+                        html.Td(item.get("text")),
+                        html.Td(", ".join(true_flags)),
+                    ]
                     rows.append(html.Tr(row))
                 judge_div = html.Table(rows, className="table table-sm table-dark")
             else:

--- a/tests/test_dashboard_llm_output.py
+++ b/tests/test_dashboard_llm_output.py
@@ -102,3 +102,9 @@ def test_update_output_callback(monkeypatch):
     )
     assert outputs[25] == fake_results
     assert any("processed results" in entry for entry in outputs[24])
+
+    table = outputs[20]
+    header_labels = [cell.children for cell in table.children[0].children]
+    assert header_labels == ["Index", "Text", "Flags"]
+    first_row = [cell.children for cell in table.children[1].children]
+    assert first_row == [0, "Buy now!", "Urgency"]


### PR DESCRIPTION
## Summary
- condense flag columns in judge results table into a single "Flags" column
- adapt dashboard tests for new table layout

## Testing
- `pytest tests/test_dashboard_llm_output.py::test_update_output_callback -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881fdde7c30832e80febc5cb80f5060