### PR TITLE
Ensure dark theme for empty graphs

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -133,6 +133,11 @@ def build_timeline_graph(heur: List[int], llm: List[int]) -> "go.Figure":
     return fig
 
 
+def empty_figure() -> "go.Figure":
+    """Return a blank dark-themed Plotly figure."""
+    return go.Figure(layout={"template": "plotly_dark"})
+
+
 
 
 def parse_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
@@ -594,8 +599,8 @@ def update_output(
             None,
             log_entries if DEBUG_MODE else debug_log,
             None,
-            go.Figure(),
-            go.Figure(),
+            empty_figure(),
+            empty_figure(),
         ]
 
     try:
@@ -622,8 +627,8 @@ def update_output(
             None,
             log_entries if DEBUG_MODE else debug_log,
             None,
-            go.Figure(),
-            go.Figure(),
+            empty_figure(),
+            empty_figure(),
         ]
 
     log("analysis complete")

--- a/tests/test_dashboard_llm_output.py
+++ b/tests/test_dashboard_llm_output.py
@@ -108,3 +108,22 @@ def test_update_output_callback(monkeypatch):
     assert header_labels == ["Index", "Text", "Flags"]
     first_row = [cell.children for cell in table.children[1].children]
     assert first_row == [0, "Buy now!", "Urgency"]
+
+
+def test_update_output_no_file_has_dark_theme():
+    outputs = da.update_output(
+        None,
+        "plain",
+        0,
+        0,
+        "openai",
+        [],
+        "foo",
+        False,
+        [],
+        None,
+    )
+    flag_fig = outputs[-2]
+    time_fig = outputs[-1]
+    assert flag_fig.layout.template.layout.paper_bgcolor == "rgb(17,17,17)"
+    assert time_fig.layout.template.layout.paper_bgcolor == "rgb(17,17,17)"


### PR DESCRIPTION
## Summary
- add `empty_figure` helper that returns a dark-themed blank Plotly figure
- use this helper in `update_output` when no data or when parsing fails
- test that empty graphs keep the dark theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688203c5f8c0832ea6f3cb2294e8c839