### PR TITLE
Handle plain 'Sender:' lines

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -4,8 +4,9 @@ import base64
 import io
 import json
 import os
+import re
 from datetime import datetime
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Tuple
 import logging
 from logging_utils import setup_logging
 
@@ -151,6 +152,7 @@ def parse_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
         data = decoded.decode('utf-8')
         lines = data.splitlines()
         msgs = []
+        pattern3 = re.compile(r'^(?P<sender>[^:]+):\s*(?P<text>.+)$')
         for line in lines:
             if not line.strip():
                 continue
@@ -163,7 +165,11 @@ def parse_uploaded_file(contents: str, filename: str) -> Dict[str, Any]:
                     continue
                 except Exception:
                     pass
-            msgs.append({'sender': None, 'timestamp': None, 'text': line})
+            match3 = pattern3.match(line)
+            if match3:
+                msgs.append({'sender': match3.group('sender').strip(), 'timestamp': None, 'text': match3.group('text').strip()})
+            else:
+                msgs.append({'sender': None, 'timestamp': None, 'text': line})
         conversation = {'conversation_id': filename.rsplit('.', 1)[0], 'messages': msgs}
     elif name.endswith('.csv'):
         data = decoded.decode('utf-8')

--- a/scripts/input_parser.py
+++ b/scripts/input_parser.py
@@ -85,6 +85,8 @@ def parse_txt_chat(txt_path: str) -> Dict[str, Any]:
     pattern2 = re.compile(
         r"^(?P<sender>[^\(]+)\s*\((?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{1,2}:\d{2}:\d{2})\):\s*(?P<text>.+)"
     )
+    # Pattern 3: Sender: text (no timestamp)
+    pattern3 = re.compile(r'^(?P<sender>[^:]+):\s*(?P<text>.+)$')
 
     with path.open('r', encoding='utf-8') as f:
         for line in f:
@@ -94,6 +96,7 @@ def parse_txt_chat(txt_path: str) -> Dict[str, Any]:
 
             match1 = pattern1.match(line)
             match2 = pattern2.match(line)
+            match3 = pattern3.match(line)
 
             if match1:
                 raw_ts = match1.group('timestamp')
@@ -117,6 +120,10 @@ def parse_txt_chat(txt_path: str) -> Dict[str, Any]:
                     timestamp = None
                 sender = match2.group('sender').strip()
                 text = match2.group('text').strip()
+            elif match3:
+                timestamp = None
+                sender = match3.group('sender').strip()
+                text = match3.group('text').strip()
             else:
                 # Fallback: no clear timestamp/sender
                 timestamp = None

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -28,6 +28,17 @@ def test_parse_uploaded_file_txt():
     assert result["messages"][1]["text"] == "hello"
 
 
+def test_parse_uploaded_file_txt_no_timestamp():
+    text = "User: hi\nBot: hello"
+    enc = base64.b64encode(text.encode()).decode()
+    contents = f"data:text/plain;base64,{enc}"
+    result = da.parse_uploaded_file(contents, "chat.txt")
+    assert result["conversation_id"] == "chat"
+    assert result["messages"][0]["sender"].lower() == "user"
+    assert result["messages"][0]["timestamp"] is None
+    assert result["messages"][1]["sender"].lower() == "bot"
+
+
 def test_parse_uploaded_file_csv():
     csv_text = "sender,text\nuser,hi\nbot,hello"
     enc = base64.b64encode(csv_text.encode()).decode()


### PR DESCRIPTION
## Summary
- support text chat entries without timestamps in `parse_txt_chat`
- parse uploaded TXT files with 'Sender: message' lines
- test the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688203dc0698832e9e8900b16675a7ed