### PR TITLE
Add python-dateutil requirement and parsing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ This section walks through a full workflow from setting up the project to analys
    cd Alethia_open_manipulation_framework
    python3 -m venv .venv
    source .venv/bin/activate
-   pip install openai python-dateutil requests pytest
-   ```
+   pip install -r requirements.txt
+  ```
 
 2. **Configure API keys**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 dash_bootstrap_components
 pytest
 gunicorn
+python-dateutil

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -7,6 +7,7 @@ os.environ["DEBUG_MODE"] = "1"
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import dashboard_app as da
+from scripts import input_parser
 
 
 def test_parse_uploaded_file_json():
@@ -35,3 +36,11 @@ def test_parse_uploaded_file_csv():
     result = da.parse_uploaded_file(contents, "log.csv")
     assert len(result["messages"]) == 2
     assert result["messages"][1]["text"] == "hello"
+
+
+def test_parse_txt_chat_timestamp(tmp_path):
+    path = tmp_path / "chat.txt"
+    path.write_text("[10:00:00] User: hi")
+    result = input_parser.parse_txt_chat(str(path))
+    ts = result["messages"][0]["timestamp"]
+    assert ts is not None and ts.endswith("10:00:00")


### PR DESCRIPTION
## Summary
- add python-dateutil to requirements
- standardize README install step
- check that plain text timestamps parse

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688203d20b90832e8af8f19f9ffd984e