### PR TITLE
Add sender standardization for dominance metrics

### DIFF
--- a/insight_helpers.py
+++ b/insight_helpers.py
@@ -1,5 +1,33 @@
 from typing import List, Dict, Any
 
+
+def standardize_sender(sender: Any) -> str:
+    """Map various sender labels to canonical ``"user"`` or ``"bot"``.
+
+    Parameters
+    ----------
+    sender : Any
+        Raw sender value from a conversation message. ``None`` or unrecognised
+        names are treated as ``"user"``.
+
+    Returns
+    -------
+    str
+        ``"bot"`` if the sender represents the assistant/system, otherwise
+        ``"user"``.
+    """
+
+    if sender is None:
+        raw = ""
+    else:
+        raw = str(sender).strip().lower()
+
+    if raw in {"bot", "assistant", "sammy", "system"}:
+        return "bot"
+    if raw == "user":
+        return "user"
+    return "user"
+
 def compute_manipulation_ratio(features: List[Dict[str, Any]]) -> float:
     total = len(features)
     if total == 0:
@@ -70,7 +98,7 @@ def compute_dominance_metrics(features: List[Dict[str, Any]]) -> Dict[str, Any]:
     for f in features:
         text = f.get('text', '') or ''
         wc = len(text.split())
-        sender = (f.get('sender') or '').lower()
+        sender = standardize_sender(f.get('sender'))
         if sender == 'user':
             user_msg_count += 1
             user_words += wc

--- a/tests/test_dominance_metrics.py
+++ b/tests/test_dominance_metrics.py
@@ -1,0 +1,27 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from scripts import input_parser
+from scripts import static_feature_extractor as sfe
+import insight_helpers as ih
+
+
+def _metrics(path: str):
+    conv = input_parser.parse_txt_chat(path)
+    conv = input_parser.standardize_format(conv)
+    features = sfe.extract_conversation_features(conv)
+    return ih.compute_dominance_metrics(features)
+
+
+def test_counts_example():
+    metrics = _metrics(os.path.join('data', 'example.txt'))
+    assert metrics['user_msg_count'] == 16
+    assert metrics['bot_msg_count'] == 16
+
+
+def test_counts_example_2():
+    metrics = _metrics(os.path.join('data', 'example_2.txt'))
+    assert metrics['user_msg_count'] == 16
+    assert metrics['bot_msg_count'] == 16
+


### PR DESCRIPTION
## Summary
- add `standardize_sender` helper for consistent user/bot names
- use it inside `compute_dominance_metrics`
- test dominance metrics on example conversations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688207e3c3e8832eb5b7840498a2e100