### PR TITLE
Add conversation type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ This section walks through a full workflow from setting up the project to analys
 
    If you used a `.txt` log, call `parse_txt_chat` instead of `parse_json_chat`.
 
+   The dashboard helper `parse_uploaded_file` performs the same parsing and
+   accepts an optional `conv_type` argument. Set ``conv_type="chatbot"`` to
+   normalise senders to ``user``/``bot`` or ``"social"`` to keep the original
+   names.
+
 5. **Extract manipulation features**
 
    ```python
@@ -130,7 +135,7 @@ This section walks through a full workflow from setting up the project to analys
 
 9. **Launch the interactive dashboard**
 
-   Start the Dash application with `python dashboard_app.py` and open `http://127.0.0.1:8050` in your browser. Upload a conversation file to explore detected manipulation patterns and download the analysis as JSON.
+   Start the Dash application with `python dashboard_app.py` and open `http://127.0.0.1:8050` in your browser. Upload a conversation file to explore detected manipulation patterns and download the analysis as JSON. Use the *Conversation Type* dropdown to choose between **Chatbot** (default) and **Social Media** modes. Chatbot mode normalizes senders into `user` and `bot`, while Social Media mode preserves all distinct names.
 
 ### Deploying to Heroku
 

--- a/tests/test_dashboard_llm_output.py
+++ b/tests/test_dashboard_llm_output.py
@@ -84,7 +84,7 @@ def test_update_output_callback(monkeypatch):
             {"index": 0, "text": "Buy now!", "flags": {"urgency": True}}
         ]
     }
-    monkeypatch.setattr(da, "parse_uploaded_file", lambda c, f: conv)
+    monkeypatch.setattr(da, "parse_uploaded_file", lambda c, f, conv_type="chatbot": conv)
     monkeypatch.setattr(da, "analyze_conversation", lambda c: analysis)
     monkeypatch.setattr(da, "judge_conversation_llm", lambda c, provider="auto": fake_results)
 
@@ -95,6 +95,7 @@ def test_update_output_callback(monkeypatch):
         1,
         "openai",
         [],
+        "chatbot",
         "conv.json",
         False,
         [],
@@ -118,6 +119,7 @@ def test_update_output_no_file_has_dark_theme():
         0,
         "openai",
         [],
+        "chatbot",
         "foo",
         False,
         [],


### PR DESCRIPTION
## Summary
- extend `parse_uploaded_file` with `conv_type` argument
- normalise sender names when `conv_type='chatbot'`
- propagate conversation type from dashboard dropdown
- update tests and documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68820731a770832eb5e6287c2fc77cd1