### PR TITLE
Warn if Dash missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This section walks through a full workflow from setting up the project to analys
 
 9. **Launch the interactive dashboard**
 
-   Start the Dash application with `python dashboard_app.py` and open `http://127.0.0.1:8050` in your browser. Upload a conversation file to explore detected manipulation patterns and download the analysis as JSON. Use the *Conversation Type* dropdown to choose between **Chatbot** (default) and **Social Media** modes. Chatbot mode normalizes senders into `user` and `bot`, while Social Media mode preserves all distinct names.
+   Make sure you've installed all dependencies with `pip install -r requirements.txt` before starting the dashboard. Then run `python dashboard_app.py` and open `http://127.0.0.1:8050` in your browser. Upload a conversation file to explore detected manipulation patterns and download the analysis as JSON. Use the *Conversation Type* dropdown to choose between **Chatbot** (default) and **Social Media** modes. Chatbot mode normalizes senders into `user` and `bot`, while Social Media mode preserves all distinct names.
 
 ### Deploying to Heroku
 

--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -18,6 +18,7 @@ from insight_helpers import (
     compute_llm_flag_timeline,
 )
 
+_Dummy = None
 try:
     import dash
     from dash import dcc, html
@@ -38,6 +39,10 @@ except Exception:  # pragma: no cover - make optional for tests
 
 setup_logging()
 logger = logging.getLogger(__name__)
+if _Dummy is not None and isinstance(dash, _Dummy):
+    logger.warning(
+        "Dash is unavailable; dashboard functionality will be disabled"
+    )
 
 DEBUG_MODE = os.getenv("DEBUG_MODE") == "1"
 


### PR DESCRIPTION
## Summary
- warn when Dash isn't available so users know dashboard features are disabled
- document running `pip install -r requirements.txt` before starting the dashboard

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688215c9558c832e9971f589148b9fad