### PR TITLE
Fix timestamp parsing fallback

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -27,6 +27,12 @@ try:
 except Exception:  # pragma: no cover - make optional for tests
     class _Dummy:
         def __getattr__(self, name):
+            if name == "callback":
+                def decorator_factory(*args, **kwargs):
+                    def decorator(func):
+                        return func
+                    return decorator
+                return decorator_factory
             return self
 
         def __call__(self, *args, **kwargs):
@@ -35,6 +41,7 @@ except Exception:  # pragma: no cover - make optional for tests
     dash = _Dummy()
     dcc = html = Input = Output = State = _Dummy()
     dbc = _Dummy()
+    go = _Dummy()
 
 setup_logging()
 logger = logging.getLogger(__name__)

--- a/scripts/input_parser.py
+++ b/scripts/input_parser.py
@@ -104,7 +104,10 @@ def parse_txt_chat(txt_path: str) -> Dict[str, Any]:
                     if _date_parser:
                         timestamp = _date_parser.parse(raw_ts)
                     else:
-                        timestamp = datetime.fromisoformat(raw_ts)
+                        try:
+                            timestamp = datetime.fromisoformat(raw_ts)
+                        except Exception:
+                            timestamp = datetime.strptime(raw_ts, "%H:%M:%S")
                 except Exception:
                     timestamp = None
                 sender = match1.group('sender').strip()
@@ -115,7 +118,10 @@ def parse_txt_chat(txt_path: str) -> Dict[str, Any]:
                     if _date_parser:
                         timestamp = _date_parser.parse(raw_ts)
                     else:
-                        timestamp = datetime.fromisoformat(raw_ts)
+                        try:
+                            timestamp = datetime.fromisoformat(raw_ts)
+                        except Exception:
+                            timestamp = datetime.strptime(raw_ts, "%H:%M:%S")
                 except Exception:
                     timestamp = None
                 sender = match2.group('sender').strip()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -55,3 +55,13 @@ def test_parse_txt_chat_timestamp(tmp_path):
     result = input_parser.parse_txt_chat(str(path))
     ts = result["messages"][0]["timestamp"]
     assert ts is not None and ts.endswith("10:00:00")
+
+
+def test_parse_txt_chat_timestamp_no_dateutil(tmp_path, monkeypatch):
+    path = tmp_path / "chat.txt"
+    path.write_text("[10:00:00] User: hi")
+
+    monkeypatch.setattr(input_parser, "_date_parser", None)
+    result = input_parser.parse_txt_chat(str(path))
+    ts = result["messages"][0]["timestamp"]
+    assert ts is not None and ts.endswith("10:00:00")


### PR DESCRIPTION
## Summary
- improve dash fallback for callback when dash isn't available
- parse `[HH:MM:SS]` timestamps when python-dateutil isn't installed
- test fallback timestamp parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688215cb1248832eb55aa3040bb2d4c3